### PR TITLE
[improve-map-task-invalid-state-logging] Add logging of the mapping function in MapTaskObservable

### DIFF
--- a/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
+++ b/monix-reactive/shared/src/main/scala/monix/reactive/internal/operators/MapTaskObservable.scala
@@ -350,7 +350,7 @@ private[reactive] final class MapTaskObservable[A, B](source: Observable[A], f: 
         new IllegalStateException(
           s"State $state in the Monix MapTask.$method implementation is invalid, " +
             "due to either a broken Subscriber implementation, or a bug, " +
-            "please open an issue, see: https://monix.io"
+            s"please open an issue, see: https://monix.io. Executed function: $f"
         ))
       // $COVERAGE-ON$
     }


### PR DESCRIPTION
`MapTaskObservable` reports invalid state on some environments.

We weren't able to reproduce it synthetically, so in an attempt to gain better understanding of the error (and it's extent) I suggest logging the function used to process each element of the Observable when such failure occurs.