### PR TITLE
Fix unsafe modification of Trampoline resources

### DIFF
--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedEvalFilterMapSumBenchmark.scala
@@ -17,8 +17,6 @@
 
 package monix.benchmarks
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Keep, RunnableGraph, Sink => AkkaSink, Source => AkkaSource}
 import fs2.{Stream => FS2Stream}
@@ -28,7 +26,7 @@ import org.openjdk.jmh.annotations._
 import zio.stream.{Stream => ZStream}
 import zio.{Chunk, UIO}
 
-import scala.collection.immutable.IndexedSeq
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
@@ -82,8 +80,8 @@ class ChunkedEvalFilterMapSumBenchmark {
   @Setup
   def setup(): Unit = {
     chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
-    fs2Chunks = chunks.map(fs2.Chunk.array)
-    zioChunks = chunks.map(zio.Chunk.fromArray)
+    fs2Chunks = chunks.map(fs2.Chunk.array[Int])
+    zioChunks = chunks.map(zio.Chunk.fromArray[Int])
     allElements = chunks.flatten
     expectedSum = allElements.map(_.toLong).sum
   }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/ChunkedMapFilterSumBenchmark.scala
@@ -17,8 +17,6 @@
 
 package monix.benchmarks
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Keep, Sink => AkkaSink, Source => AkkaSource}
 import fs2.{Stream => FS2Stream}
@@ -29,7 +27,7 @@ import monix.reactive.observers.Subscriber
 import org.openjdk.jmh.annotations._
 import zio.stream.{Stream => ZStream}
 
-import scala.collection.immutable.IndexedSeq
+import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Promise}
 
@@ -68,8 +66,8 @@ class ChunkedMapFilterSumBenchmark {
   @Setup
   def setup(): Unit = {
     chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
-    fs2Chunks = chunks.map(fs2.Chunk.array)
-    zioChunks = chunks.map(zio.Chunk.fromArray)
+    fs2Chunks = chunks.map(fs2.Chunk.array[Int])
+    zioChunks = chunks.map(zio.Chunk.fromArray[Int])
     allElements = chunks.flatten
     allElementsVector = allElements.toVector
   }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolineExecutionContextBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolineExecutionContextBenchmark.scala
@@ -25,19 +25,19 @@ import scala.concurrent.blocking
 
 /** To do comparative benchmarks between versions:
   *
-  *     benchmarks/run-benchmark TrampolinedRunnableBenchmark
+  *     benchmarks/run-benchmark TrampolineExecutionContextBenchmark
   *
   * This will generate results in `benchmarks/results`.
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     jmh:run monix.benchmarks.TrampolineExecutionContextBenchmark
   *     The above test will take default values as "10 iterations", "10 warm-up iterations",
   *     "2 forks", "1 thread".
   *
   *     Or to specify custom values use below format:
   *
-  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TrampolineExecutionContextBenchmark
   *
   * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolineExecutionContextBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolineExecutionContextBenchmark.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2021 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monix.benchmarks
+
+import monix.execution.schedulers.TrampolineExecutionContext
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.blocking
+
+/** To do comparative benchmarks between versions:
+  *
+  *     benchmarks/run-benchmark TrampolinedRunnableBenchmark
+  *
+  * This will generate results in `benchmarks/results`.
+  *
+  * Or to run the benchmark from within SBT:
+  *
+  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     The above test will take default values as "10 iterations", "10 warm-up iterations",
+  *     "2 forks", "1 thread".
+  *
+  *     Or to specify custom values use below format:
+  *
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *
+  * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
+  * Please note that benchmarks should be usually executed at least in
+  * 10 iterations (as a rule of thumb), but more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10)
+@Warmup(iterations = 10)
+@Fork(2)
+@Threads(1)
+class TrampolineExecutionContextBenchmark {
+  @Param(Array("3000"))
+  var size: Int = _
+
+  @Benchmark
+  def immediateBlocking(): Long = {
+    var sum = 0L
+    val context = TrampolineExecutionContext.immediate
+
+    context.execute { () =>
+      var i = size
+      while (i > size / 2) {
+        context.execute(() => sum += i)
+        i -= 1
+      }
+      blocking {
+        while (i > 0) {
+          context.execute(() => sum += i)
+          i -= 1
+        }
+      }
+    }
+    sum
+  }
+}

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
@@ -29,13 +29,13 @@ import org.openjdk.jmh.annotations._
   *
   * Or to run the benchmark from within SBT:
   *
-  *     jmh:run monix.benchmarks.TaskShiftBenchmark
+  *     jmh:run monix.benchmarks.TrampolinedRunnableBenchmark
   *     The above test will take default values as "10 iterations", "10 warm-up iterations",
   *     "2 forks", "1 thread".
   *
   *     Or to specify custom values use below format:
   *
-  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TaskShiftBenchmark
+  *     jmh:run -i 20 -wi 20 -f 4 -t 2 monix.benchmarks.TrampolinedRunnableBenchmark
   *
   * Which means "20 iterations", "20 warm-up iterations", "4 forks", "2 thread".
   * Please note that benchmarks should be usually executed at least in

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
@@ -66,17 +66,17 @@ class TrampolinedRunnableBenchmark {
     sum
   }
 
-//  @Benchmark
-//  def deep(): Long = {
-//    var sum = 0L
-//
-//    global.executeTrampolined { () =>
-//      var i = size
-//      while (i > 0) {
-//        global.executeTrampolined(() => sum += i)
-//        i -= 1
-//      }
-//    }
-//    sum
-//  }
+  @Benchmark
+  def deep(): Long = {
+    var sum = 0L
+
+    global.executeTrampolined { () =>
+      var i = size
+      while (i > 0) {
+        global.executeTrampolined(() => sum += i)
+        i -= 1
+      }
+    }
+    sum
+  }
 }

--- a/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
+++ b/benchmarks/shared/src/main/scala/monix/benchmarks/TrampolinedRunnableBenchmark.scala
@@ -74,7 +74,7 @@ class TrampolinedRunnableBenchmark {
 //      var i = size
 //      while (i > 0) {
 //        global.executeTrampolined(() => sum += i)
-//        i += 1
+//        i -= 1
 //      }
 //    }
 //    sum

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,7 +18,7 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
-import monix.execution.internal.Trampoline.{ForkingEC, ImmediateEC, TrampolineEC}
+import monix.execution.internal.Trampoline.{ForkingTrampolineEC, ImmediateTrampolineEC, TrampolineEC}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -70,7 +70,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(new ForkingEC(underlying))
+    new TrampolineExecutionContext(new ForkingTrampolineEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.
@@ -86,5 +86,5 @@ object TrampolineExecutionContext {
     *    have no way to override it)
     */
   val immediate: TrampolineExecutionContext =
-    new TrampolineExecutionContext(ImmediateEC)
+    new TrampolineExecutionContext(ImmediateTrampolineEC)
 }

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -20,7 +20,7 @@ package monix.execution.schedulers
 import monix.execution.internal.Trampoline
 import monix.execution.internal.Trampoline.{ImmediateEC, TrampolineEC}
 
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
 /** A `scala.concurrentExecutionContext` implementation
   * that executes runnables immediately, on the current thread,
@@ -69,8 +69,8 @@ object TrampolineExecutionContext {
     *        it defers to in case asynchronous or time-delayed execution
     *        is needed
     */
-  def apply(underlying: TrampolineEC): TrampolineExecutionContext =
-    new TrampolineExecutionContext(underlying)
+  def apply(underlying: ExecutionContext): TrampolineExecutionContext =
+    new TrampolineExecutionContext(new Trampoline.ForkingEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,7 +18,7 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
-import monix.execution.internal.Trampoline.{ImmediateEC, TrampolineEC}
+import monix.execution.internal.Trampoline.{ForkingEC, ImmediateEC, TrampolineEC}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -70,7 +70,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(new Trampoline.ForkingEC(underlying))
+    new TrampolineExecutionContext(new ForkingEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.

--- a/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/js/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,8 +18,9 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
+import monix.execution.internal.Trampoline.{ImmediateEC, TrampolineEC}
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.concurrent.ExecutionContextExecutor
 
 /** A `scala.concurrentExecutionContext` implementation
   * that executes runnables immediately, on the current thread,
@@ -51,7 +52,7 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
   * @param underlying is the `ExecutionContext` to which the it defers
   *        to in case real asynchronous is needed
   */
-final class TrampolineExecutionContext private (underlying: ExecutionContext) extends ExecutionContextExecutor {
+final class TrampolineExecutionContext private (underlying: TrampolineEC) extends ExecutionContextExecutor {
 
   private[this] val trampoline = new Trampoline
 
@@ -68,7 +69,7 @@ object TrampolineExecutionContext {
     *        it defers to in case asynchronous or time-delayed execution
     *        is needed
     */
-  def apply(underlying: ExecutionContext): TrampolineExecutionContext =
+  def apply(underlying: TrampolineEC): TrampolineExecutionContext =
     new TrampolineExecutionContext(underlying)
 
   /** [[TrampolineExecutionContext]] instance that executes everything
@@ -85,8 +86,5 @@ object TrampolineExecutionContext {
     *    have no way to override it)
     */
   val immediate: TrampolineExecutionContext =
-    TrampolineExecutionContext(new ExecutionContext {
-      def execute(r: Runnable): Unit = r.run()
-      def reportFailure(e: Throwable): Unit = throw e
-    })
+    new TrampolineExecutionContext(ImmediateEC)
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -68,7 +68,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(Trampoline.ForkingECImpl(underlying))
+    new TrampolineExecutionContext(new Trampoline.ForkingEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -124,7 +124,7 @@ object TrampolineExecutionContext {
       new JVMNormalTrampoline()
   }
 
-  private final class JVMOptimalTrampoline extends Trampoline {
+  private final class JVMOptimalTrampoline extends Trampoline(fallbackTrampoline = Some(() => trampoline.get())) {
     override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
       val parentContext = localContext.get()
       localContext.set(trampolineContext(parentContext, ec))
@@ -136,7 +136,7 @@ object TrampolineExecutionContext {
     }
   }
 
-  private class JVMNormalTrampoline extends Trampoline {
+  private class JVMNormalTrampoline extends Trampoline(fallbackTrampoline = Some(() => trampoline.get())) {
     override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
       BlockContext.withBlockContext(trampolineContext(BlockContext.current, ec)) {
         super.startLoop(runnable, ec)

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,7 +18,7 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
-import monix.execution.internal.Trampoline.{ImmediateEC, TrampolineEC}
+import monix.execution.internal.Trampoline.{ForkingEC, ImmediateEC, TrampolineEC}
 
 import scala.concurrent.{BlockContext, ExecutionContext, ExecutionContextExecutor}
 import scala.util.control.NonFatal
@@ -68,7 +68,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(new Trampoline.ForkingEC(underlying))
+    new TrampolineExecutionContext(new ForkingEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,9 +18,10 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
+import monix.execution.internal.Trampoline.{ImmediateEC, TrampolineEC}
 
-import scala.util.control.NonFatal
 import scala.concurrent.{BlockContext, ExecutionContext, ExecutionContextExecutor}
+import scala.util.control.NonFatal
 
 /** A `scala.concurrentExecutionContext` implementation
   * that executes runnables immediately, on the current thread,
@@ -52,7 +53,7 @@ import scala.concurrent.{BlockContext, ExecutionContext, ExecutionContextExecuto
   * @param underlying is the `ExecutionContext` to which the it defers
   *        to in case real asynchronous is needed
   */
-final class TrampolineExecutionContext private (underlying: ExecutionContext) extends ExecutionContextExecutor {
+final class TrampolineExecutionContext private (underlying: TrampolineEC) extends ExecutionContextExecutor {
   override def execute(runnable: Runnable): Unit =
     TrampolineExecutionContext.trampoline.get().execute(runnable, underlying)
   override def reportFailure(t: Throwable): Unit =
@@ -67,7 +68,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(underlying)
+    new TrampolineExecutionContext(Trampoline.ForkingECImpl(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.
@@ -83,10 +84,7 @@ object TrampolineExecutionContext {
     *    have no way to override it)
     */
   val immediate: TrampolineExecutionContext =
-    TrampolineExecutionContext(new ExecutionContext {
-      def execute(r: Runnable): Unit = r.run()
-      def reportFailure(e: Throwable): Unit = throw e
-    })
+    new TrampolineExecutionContext(ImmediateEC)
 
   /** Returns the `localContext`, allowing us to bypass calling
     * `BlockContext.withBlockContext`, as an optimization trick.
@@ -125,7 +123,7 @@ object TrampolineExecutionContext {
   }
 
   private final class JVMOptimalTrampoline extends Trampoline(fallbackTrampoline = Some(() => trampoline.get())) {
-    override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
+    override def startLoop(runnable: Runnable, ec: TrampolineEC): Unit = {
       val parentContext = localContext.get()
       localContext.set(trampolineContext(parentContext, ec))
       try {
@@ -137,7 +135,7 @@ object TrampolineExecutionContext {
   }
 
   private class JVMNormalTrampoline extends Trampoline(fallbackTrampoline = Some(() => trampoline.get())) {
-    override def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
+    override def startLoop(runnable: Runnable, ec: TrampolineEC): Unit = {
       BlockContext.withBlockContext(trampolineContext(BlockContext.current, ec)) {
         super.startLoop(runnable, ec)
       }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/TrampolineExecutionContext.scala
@@ -18,7 +18,7 @@
 package monix.execution.schedulers
 
 import monix.execution.internal.Trampoline
-import monix.execution.internal.Trampoline.{ForkingEC, ImmediateEC, TrampolineEC}
+import monix.execution.internal.Trampoline.{ForkingTrampolineEC, ImmediateTrampolineEC, TrampolineEC}
 
 import scala.concurrent.{BlockContext, ExecutionContext, ExecutionContextExecutor}
 import scala.util.control.NonFatal
@@ -68,7 +68,7 @@ object TrampolineExecutionContext {
     *        is needed
     */
   def apply(underlying: ExecutionContext): TrampolineExecutionContext =
-    new TrampolineExecutionContext(new ForkingEC(underlying))
+    new TrampolineExecutionContext(new ForkingTrampolineEC(underlying))
 
   /** [[TrampolineExecutionContext]] instance that executes everything
     * immediately, on the current thread.
@@ -84,7 +84,7 @@ object TrampolineExecutionContext {
     *    have no way to override it)
     */
   val immediate: TrampolineExecutionContext =
-    new TrampolineExecutionContext(ImmediateEC)
+    new TrampolineExecutionContext(ImmediateTrampolineEC)
 
   /** Returns the `localContext`, allowing us to bypass calling
     * `BlockContext.withBlockContext`, as an optimization trick.

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -18,9 +18,9 @@
 package monix.execution.schedulers
 
 import minitest.SimpleTestSuite
-import monix.execution.{ ExecutionModel, Scheduler, UncaughtExceptionReporter }
+import monix.execution.{ExecutionModel, Scheduler, UncaughtExceptionReporter}
 
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -18,9 +18,9 @@
 package monix.execution.schedulers
 
 import minitest.SimpleTestSuite
-import monix.execution.{ExecutionModel, Scheduler, UncaughtExceptionReporter}
+import monix.execution.{ ExecutionModel, Scheduler, UncaughtExceptionReporter }
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
@@ -57,11 +57,12 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     assertEquals(effect, 3)
   }
 
-  test("trampoline works for problematic case") {
+  test("trampoline works for nested executions") {
     final class TestException extends NoStackTrace
 
     val timeoutMillis = 5000
     val didTimeout = new AtomicBoolean(false)
+    // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
     val totalTasks = 32
     val tasksCounter = new AtomicInteger(0)
 
@@ -84,29 +85,29 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
         Thread.onSpinWait()
       }
       if (System.currentTimeMillis() >= timeout) {
-        // tasks used to get stuck in the trampoline run loop, this shouldn't happen anymore, but trying to
-        // detect it with a timeout
+        // tasks used to get stuck / be skipped in the trampoline run loop,
+        // trying to detect it with a timeout
         println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
         didTimeout.set(true)
       }
     }
 
-    def executeProblematicTrampoline(): Unit = {
+    def executeNestedTrampoline(): Unit = {
       context.execute {
         () =>
-          // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale headArray reference
-          (1 to 32).foreach { i =>
+          (1 to totalTasks).foreach { i =>
             context.execute { () =>
               tasksCounter.incrementAndGet()
               fail()
             }
           }
+          fail()
       }
       waitForAllExecutions()
     }
 
-    (1 to 100).foreach { _ =>
-      executeProblematicTrampoline()
+    (1 to 1000).foreach { _ =>
+      executeNestedTrampoline()
     }
     assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
   }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -18,9 +18,9 @@
 package monix.execution.schedulers
 
 import minitest.SimpleTestSuite
-import monix.execution.{ExecutionModel, Scheduler, UncaughtExceptionReporter}
+import monix.execution.{ ExecutionModel, Scheduler, UncaughtExceptionReporter }
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
@@ -64,7 +64,6 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     val didTimeoutOrFail = new AtomicBoolean(false)
     // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
     val totalTasks = 32
-    val tasksCounter = new AtomicInteger(0)
 
     def ignoreTestExceptions: UncaughtExceptionReporter = {
       case _: TestException =>
@@ -79,22 +78,24 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
       reporter = ignoreTestExceptions
     ))
 
-    def fail(): Unit = throw new TestException
-
-    def waitForAllExecutions(): Unit = {
-      val timeout = System.currentTimeMillis() + timeoutMillis
-      while (tasksCounter.get() < totalTasks && System.currentTimeMillis() < timeout) {
-        Thread.onSpinWait()
-      }
-      if (System.currentTimeMillis() >= timeout) {
-        // tasks used to get stuck / be skipped in the trampoline run loop,
-        // trying to detect it with a timeout
-        println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
-        didTimeoutOrFail.set(true)
-      }
-    }
-
     def executeNestedTrampoline(): Unit = {
+      val tasksCounter = new AtomicInteger(0)
+
+      def fail(): Unit = throw new TestException
+
+      def waitForAllExecutions(): Unit = {
+        val timeout = System.currentTimeMillis() + timeoutMillis
+        while (tasksCounter.get() < totalTasks && System.currentTimeMillis() < timeout) {
+          Thread.onSpinWait()
+        }
+        if (System.currentTimeMillis() >= timeout) {
+          // tasks used to get stuck / be skipped in the trampoline run loop,
+          // trying to detect it with a timeout
+          println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
+          didTimeoutOrFail.set(true)
+        }
+      }
+
       context.execute {
         () =>
           (1 to totalTasks).foreach { i =>

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -18,6 +18,10 @@
 package monix.execution.schedulers
 
 import minitest.SimpleTestSuite
+import monix.execution.{ExecutionModel, Scheduler, UncaughtExceptionReporter}
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
   test("TrampolineExecutionContext.immediate works") {
@@ -51,5 +55,59 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     }
 
     assertEquals(effect, 3)
+  }
+
+  test("trampoline works for problematic case") {
+    final class TestException extends NoStackTrace
+
+    val timeoutMillis = 5000
+    val didTimeout = new AtomicBoolean(false)
+    val totalTasks = 32
+    val tasksCounter = new AtomicInteger(0)
+
+    def ignoreTestExceptions: UncaughtExceptionReporter = {
+      case _: TestException =>
+      case x => x.printStackTrace()
+    }
+
+    val context = TrampolineExecutionContext(Scheduler.io(
+      name = "test",
+      executionModel = ExecutionModel.AlwaysAsyncExecution,
+      reporter = ignoreTestExceptions
+    ))
+
+    def fail(): Unit = throw new TestException
+
+    def waitForAllExecutions(): Unit = {
+      val timeout = System.currentTimeMillis() + timeoutMillis
+      while (tasksCounter.get() < totalTasks && System.currentTimeMillis() < timeout) {
+        Thread.onSpinWait()
+      }
+      if (System.currentTimeMillis() >= timeout) {
+        // tasks used to get stuck in the trampoline run loop, this shouldn't happen anymore, but trying to
+        // detect it with a timeout
+        println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
+        didTimeout.set(true)
+      }
+    }
+
+    def executeProblematicTrampoline(): Unit = {
+      context.execute {
+        () =>
+          // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale headArray reference
+          (1 to 32).foreach { i =>
+            context.execute { () =>
+              tasksCounter.incrementAndGet()
+              fail()
+            }
+          }
+      }
+      waitForAllExecutions()
+    }
+
+    (1 to 100).foreach { _ =>
+      executeProblematicTrampoline()
+    }
+    assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
   }
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -25,7 +25,7 @@ import scala.concurrent.blocking
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
-  private final val DoNothing: () => Unit = () => ()
+  private val DoNothing = () => ()
 
   final class TestException extends NoStackTrace
 
@@ -88,7 +88,7 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
 
   private def testNestedExecutions(
     scheduler: UncaughtExceptionReporter => Scheduler,
-    onExecute: () => Unit = fail,
+    onExecute: () => Unit = failExecution,
     isBlocking: Boolean = false,
   ): Unit = {
     val didFail = new AtomicBoolean(false)
@@ -106,14 +106,13 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
       x.printStackTrace()
   }
 
-  def fail(): Unit = throw new TestException
+  def failExecution(): Unit = throw new TestException
 
   private def testAllTasksExecuteCorrectly(
     context: TrampolineExecutionContext,
     onExecute: () => Unit,
     isBlocking: Boolean = false,
   ): Unit = {
-    val didTimeout = new AtomicBoolean(false)
     val timeoutMillis = 5000
     // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
     val totalNestedTasks = 32
@@ -125,15 +124,14 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
 
       def waitForAllExecutions(): Unit = {
         val timeout = System.currentTimeMillis() + timeoutMillis
+        // tasks used to get stuck / be skipped in the trampoline run loop, so applying a timeout
         while (tasksCounter.get() < totalTasks && System.currentTimeMillis() < timeout) {
           Thread.onSpinWait()
         }
-        if (System.currentTimeMillis() >= timeout) {
-          // tasks used to get stuck / be skipped in the trampoline run loop,
-          // trying to detect it with a timeout
-          println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
-          didTimeout.set(true)
-        }
+        assert(
+          tasksCounter.get() == totalTasks, // assert no skipped / duplicated task executions
+          s"Expected $totalTasks tasks to be executed, but ${tasksCounter.get()} were executed"
+        )
       }
 
       def scheduleRegisteredExecution(code: () => Unit = DoNothing): Unit = context.execute { () =>
@@ -157,7 +155,6 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     (1 to 1000).foreach { _ =>
       executeNestedTrampoline()
     }
-    assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
   }
 
   private def asyncIoScheduler(reporter: UncaughtExceptionReporter) =

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -21,9 +21,12 @@ import minitest.SimpleTestSuite
 import monix.execution.{ExecutionModel, Scheduler, UncaughtExceptionReporter}
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import scala.concurrent.blocking
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
+  private final val DoNothing: () => Unit = () => ()
+
   final class TestException extends NoStackTrace
 
   test("TrampolineExecutionContext.immediate works") {
@@ -60,9 +63,7 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
   }
 
   test("trampoline works for nested executions in async multithreaded context") {
-    testNestedExecutions(reporter =>
-      Scheduler.io(name = "test", executionModel = ExecutionModel.AlwaysAsyncExecution, reporter = reporter)
-    )
+    testNestedExecutions(asyncIoScheduler)
   }
 
   test("trampoline works for nested executions in async singlethreaded context") {
@@ -78,17 +79,23 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
   }
 
   test("trampoline works for nested executions in immediate context") {
-    testAllTasksExecuteCorrectly(TrampolineExecutionContext.immediate, () => ())
+    testAllTasksExecuteCorrectly(context = TrampolineExecutionContext.immediate, onExecute = DoNothing)
+  }
+
+  test("trampoline works for nested blocking executions") {
+    testNestedExecutions(scheduler = asyncIoScheduler, onExecute = DoNothing, isBlocking = true)
   }
 
   private def testNestedExecutions(
     scheduler: UncaughtExceptionReporter => Scheduler,
+    onExecute: () => Unit = fail,
+    isBlocking: Boolean = false,
   ): Unit = {
     val didFail = new AtomicBoolean(false)
 
     val context = TrampolineExecutionContext(scheduler(registerUnexpectedExceptions(didFail)))
 
-    testAllTasksExecuteCorrectly(context, fail)
+    testAllTasksExecuteCorrectly(context, onExecute, isBlocking)
     assert(!didFail.get(), "Unexpected exception occurred")
   }
 
@@ -104,11 +111,14 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
   private def testAllTasksExecuteCorrectly(
     context: TrampolineExecutionContext,
     onExecute: () => Unit,
+    isBlocking: Boolean = false,
   ): Unit = {
     val didTimeout = new AtomicBoolean(false)
     val timeoutMillis = 5000
     // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
-    val totalTasks = 32
+    val totalNestedTasks = 32
+    // +1 top level task
+    val totalTasks = totalNestedTasks + 1
 
     def executeNestedTrampoline(): Unit = {
       val tasksCounter = new AtomicInteger(0)
@@ -126,16 +136,21 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
         }
       }
 
-      context.execute {
-        () =>
-          (1 to totalTasks).foreach { _ =>
-            context.execute { () =>
-              tasksCounter.incrementAndGet()
-              onExecute()
-            }
-          }
-          onExecute()
+      def scheduleRegisteredExecution(code: () => Unit = DoNothing): Unit = context.execute { () =>
+        code()
+        tasksCounter.incrementAndGet()
+        onExecute()
       }
+
+      scheduleRegisteredExecution(() =>
+        (1 to totalNestedTasks).foreach { _ =>
+          if (isBlocking) {
+            blocking(scheduleRegisteredExecution())
+          } else {
+            scheduleRegisteredExecution()
+          }
+        }
+      )
       waitForAllExecutions()
     }
 
@@ -144,4 +159,7 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     }
     assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
   }
+
+  private def asyncIoScheduler(reporter: UncaughtExceptionReporter) =
+    Scheduler.io(name = "test", executionModel = ExecutionModel.AlwaysAsyncExecution, reporter = reporter)
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -61,14 +61,16 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     final class TestException extends NoStackTrace
 
     val timeoutMillis = 5000
-    val didTimeout = new AtomicBoolean(false)
+    val didTimeoutOrFail = new AtomicBoolean(false)
     // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
     val totalTasks = 32
     val tasksCounter = new AtomicInteger(0)
 
     def ignoreTestExceptions: UncaughtExceptionReporter = {
       case _: TestException =>
-      case x => x.printStackTrace()
+      case x =>
+        didTimeoutOrFail.set(true)
+        x.printStackTrace()
     }
 
     val context = TrampolineExecutionContext(Scheduler.io(
@@ -88,7 +90,7 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
         // tasks used to get stuck / be skipped in the trampoline run loop,
         // trying to detect it with a timeout
         println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
-        didTimeout.set(true)
+        didTimeoutOrFail.set(true)
       }
     }
 
@@ -109,6 +111,9 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     (1 to 1000).foreach { _ =>
       executeNestedTrampoline()
     }
-    assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
+    assert(
+      !didTimeoutOrFail.get(),
+      "Executions inside the trampoline should not timeout, nor throw unexpected exceptions"
+    )
   }
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/TrampolineExecutionContextSuite.scala
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.util.control.NoStackTrace
 
 object TrampolineExecutionContextSuite extends SimpleTestSuite {
+  final class TestException extends NoStackTrace
+
   test("TrampolineExecutionContext.immediate works") {
     val ctx = TrampolineExecutionContext.immediate
     var effect = 0
@@ -57,31 +59,59 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     assertEquals(effect, 3)
   }
 
-  test("trampoline works for nested executions") {
-    final class TestException extends NoStackTrace
+  test("trampoline works for nested executions in async multithreaded context") {
+    testNestedExecutions(reporter =>
+      Scheduler.io(name = "test", executionModel = ExecutionModel.AlwaysAsyncExecution, reporter = reporter)
+    )
+  }
 
+  test("trampoline works for nested executions in async singlethreaded context") {
+    testNestedExecutions(reporter =>
+      Scheduler.singleThread(name = "test", executionModel = ExecutionModel.AlwaysAsyncExecution, reporter = reporter)
+    )
+  }
+
+  test("trampoline works for nested executions in sync singlethreaded context") {
+    testNestedExecutions(reporter =>
+      Scheduler.singleThread(name = "test", executionModel = ExecutionModel.SynchronousExecution, reporter = reporter)
+    )
+  }
+
+  test("trampoline works for nested executions in immediate context") {
+    testAllTasksExecuteCorrectly(TrampolineExecutionContext.immediate, () => ())
+  }
+
+  private def testNestedExecutions(
+    scheduler: UncaughtExceptionReporter => Scheduler,
+  ): Unit = {
+    val didFail = new AtomicBoolean(false)
+
+    val context = TrampolineExecutionContext(scheduler(registerUnexpectedExceptions(didFail)))
+
+    testAllTasksExecuteCorrectly(context, fail)
+    assert(!didFail.get(), "Unexpected exception occurred")
+  }
+
+  def registerUnexpectedExceptions(didFail: AtomicBoolean): UncaughtExceptionReporter = {
+    case _: TestException =>
+    case x =>
+      didFail.set(true)
+      x.printStackTrace()
+  }
+
+  def fail(): Unit = throw new TestException
+
+  private def testAllTasksExecuteCorrectly(
+    context: TrampolineExecutionContext,
+    onExecute: () => Unit,
+  ): Unit = {
+    val didTimeout = new AtomicBoolean(false)
     val timeoutMillis = 5000
-    val didTimeoutOrFail = new AtomicBoolean(false)
     // 32 to fill 2 chunks of ChunkedArrayQueue, trying to expose a stale reference (e.g. headArray)
     val totalTasks = 32
 
-    def ignoreTestExceptions: UncaughtExceptionReporter = {
-      case _: TestException =>
-      case x =>
-        didTimeoutOrFail.set(true)
-        x.printStackTrace()
-    }
-
-    val context = TrampolineExecutionContext(Scheduler.io(
-      name = "test",
-      executionModel = ExecutionModel.AlwaysAsyncExecution,
-      reporter = ignoreTestExceptions
-    ))
-
     def executeNestedTrampoline(): Unit = {
       val tasksCounter = new AtomicInteger(0)
-
-      def fail(): Unit = throw new TestException
 
       def waitForAllExecutions(): Unit = {
         val timeout = System.currentTimeMillis() + timeoutMillis
@@ -92,19 +122,19 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
           // tasks used to get stuck / be skipped in the trampoline run loop,
           // trying to detect it with a timeout
           println(s"Timeout reached, only ${tasksCounter.get()} tasks executed out of $totalTasks")
-          didTimeoutOrFail.set(true)
+          didTimeout.set(true)
         }
       }
 
       context.execute {
         () =>
-          (1 to totalTasks).foreach { i =>
+          (1 to totalTasks).foreach { _ =>
             context.execute { () =>
               tasksCounter.incrementAndGet()
-              fail()
+              onExecute()
             }
           }
-          fail()
+          onExecute()
       }
       waitForAllExecutions()
     }
@@ -112,9 +142,6 @@ object TrampolineExecutionContextSuite extends SimpleTestSuite {
     (1 to 1000).foreach { _ =>
       executeNestedTrampoline()
     }
-    assert(
-      !didTimeoutOrFail.get(),
-      "Executions inside the trampoline should not timeout, nor throw unexpected exceptions"
-    )
+    assert(!didTimeout.get(), "Executions inside the trampoline should not timeout")
   }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -61,7 +61,7 @@ private[execution] class Trampoline(
   }
 
   private def forkTheRest(head: Runnable, ec: TrampolineEC): Unit = {
-    val rest = immediateQueue.shallowCopy()
+    val rest = immediateQueue
     immediateQueue = Trampoline.makeQueue()
     ec.execute(new ResumeRun(head, rest, ec, trampolineForResume()))
   }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -17,7 +17,7 @@
 
 package monix.execution.internal
 
-import monix.execution.internal.Trampoline.{ResumeRun, TrampolineEC}
+import monix.execution.internal.Trampoline.{ForkingTrampolineEC, ImmediateTrampolineEC, ResumeRun, TrampolineEC}
 import monix.execution.internal.collection.ChunkedArrayQueue
 
 import scala.annotation.tailrec
@@ -52,15 +52,14 @@ private[execution] class Trampoline(
   private def continueExecution(ec: TrampolineEC): Unit = {
     val head = immediateQueue.dequeue()
     if (head ne null) {
-      if (ec.isImmediate) {
-        immediateLoop(head, ec)
-      } else {
-        forkTheRest(head, ec)
+      ec match {
+        case ImmediateTrampolineEC => immediateLoop(head, ec)
+        case ec: ForkingTrampolineEC => forkTheRest(head, ec)
       }
     }
   }
 
-  private def forkTheRest(head: Runnable, ec: TrampolineEC): Unit = {
+  private def forkTheRest(head: Runnable, ec: ForkingTrampolineEC): Unit = {
     val rest = immediateQueue
     immediateQueue = Trampoline.makeQueue()
     ec.execute(new ResumeRun(head, rest, ec, trampolineForResume()))
@@ -112,26 +111,28 @@ private[execution] class Trampoline(
 private[execution] object Trampoline {
 
   /** ExecutionContext backing the [[Trampoline]]. */
-  trait TrampolineEC {
-    def execute(runnable: Runnable): Unit
+  sealed trait TrampolineEC {
     def reportFailure(e: Throwable): Unit
-    def isImmediate: Boolean
   }
 
-  /** Forking ExecutionContext backing the [[Trampoline]]. */
-  final class ForkingEC(ec: ExecutionContext) extends TrampolineEC {
-    def execute(runnable: Runnable): Unit = ec.execute(runnable)
-    def reportFailure(e: Throwable): Unit = ec.reportFailure(e)
-    def isImmediate: Boolean = false
-  }
-
-  /** Immediate ExecutionContext backing the [[Trampoline]].
-   *  Executes everything on the current thread. Used for optimization of the run loop.
+  /** 
+   * Trampoline backed by ForkingTrampolineEC handles problematic situations (unexpected exceptions or blocking 
+   * operations) by scheduling the remaining tasks to be executed on this execution context.
    */
-  object ImmediateEC extends TrampolineEC {
-    override def execute(runnable: Runnable): Unit = runnable.run()
+  final class ForkingTrampolineEC(ec: ExecutionContext) extends TrampolineEC {
+    def execute(runnable: Runnable): Unit = ec.execute(runnable)
+    override def reportFailure(e: Throwable): Unit = ec.reportFailure(e)
+  }
+
+  /**
+   * Trampoline backed by ImmediateTrampolineEC executes everything on the current thread.
+   * Used for optimization of the run loop.
+   * 
+   * WARNING: Using this ExecutionContext can lead to stack overflow errors if too many trampolined tasks throw
+   * an exception or too many blocking operations are chained.
+   */
+  object ImmediateTrampolineEC extends TrampolineEC {
     override def reportFailure(e: Throwable): Unit = throw e
-    override def isImmediate: Boolean = true
   }
 
   private final class ResumeRun(

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -119,17 +119,14 @@ private[execution] object Trampoline {
   }
 
   /** Forking ExecutionContext backing the [[Trampoline]]. */
-  trait ForkingEC extends TrampolineEC {
+  final class ForkingEC(ec: ExecutionContext) extends TrampolineEC {
+    def execute(runnable: Runnable): Unit = ec.execute(runnable)
+    def reportFailure(e: Throwable): Unit = ec.reportFailure(e)
     def isImmediate: Boolean = false
   }
 
-  final case class ForkingECImpl(ec: ExecutionContext) extends ForkingEC {
-    override def execute(runnable: Runnable): Unit = ec.execute(runnable)
-    override def reportFailure(e: Throwable): Unit = ec.reportFailure(e)
-  }
-
-  /** Immediate ExecutionContext that executes everything on the current thread.
-   *  Used for optimization of the run loop.
+  /** Immediate ExecutionContext backing the [[Trampoline]].
+   *  Executes everything on the current thread. Used for optimization of the run loop.
    */
   object ImmediateEC extends TrampolineEC {
     override def execute(runnable: Runnable): Unit = runnable.run()
@@ -147,7 +144,7 @@ private[execution] object Trampoline {
     def run(): Unit = {
       val trampoline = fallbackTrampoline()
       trampoline.enqueueAll(rest)
-      // Underlying Ec might have scheduled ResumeRun to execute on the same thread, we still need to check if we're
+      // Underlying EC might have scheduled ResumeRun to execute on the same thread, we still need to check if we're
       // already in the loop - thus execute.
       trampoline.execute(head, ec)
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -18,9 +18,10 @@
 package monix.execution.internal
 
 import monix.execution.internal.collection.ChunkedArrayQueue
-import scala.util.control.NonFatal
+
 import scala.annotation.tailrec
 import scala.concurrent.{BlockContext, CanAwait, ExecutionContext}
+import scala.util.control.NonFatal
 
 private[execution] class Trampoline {
   private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)
@@ -54,7 +55,7 @@ private[execution] class Trampoline {
 
     val head = immediateQueue.dequeue()
     if (head ne null) {
-      val rest = immediateQueue
+      val rest = immediateQueue.shallowCopy()
       immediateQueue = makeQueue()
       ec.execute(new ResumeRun(head, rest))
     }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -17,7 +17,7 @@
 
 package monix.execution.internal
 
-import monix.execution.internal.Trampoline.ResumeRun
+import monix.execution.internal.Trampoline.{ResumeRun, TrampolineEC}
 import monix.execution.internal.collection.ChunkedArrayQueue
 
 import scala.annotation.tailrec
@@ -30,7 +30,7 @@ private[execution] class Trampoline(
   private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue()
   private[this] var withinLoop: Boolean = false
 
-  def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
+  def startLoop(runnable: Runnable, ec: TrampolineEC): Unit = {
     withinLoop = true
     try immediateLoop(runnable, ec)
     finally {
@@ -38,7 +38,7 @@ private[execution] class Trampoline(
     }
   }
 
-  final def execute(runnable: Runnable, ec: ExecutionContext): Unit = {
+  final def execute(runnable: Runnable, ec: TrampolineEC): Unit = {
     if (!withinLoop) {
       startLoop(runnable, ec)
     } else {
@@ -49,13 +49,21 @@ private[execution] class Trampoline(
   final def enqueueAll(chunkedArrayQueue: ChunkedArrayQueue[Runnable]): Unit =
     immediateQueue.enqueueAll(chunkedArrayQueue)
 
-  private def forkTheRest(ec: ExecutionContext): Unit = {
+  private def continueExecution(ec: TrampolineEC): Unit = {
     val head = immediateQueue.dequeue()
     if (head ne null) {
-      val rest = immediateQueue.shallowCopy()
-      immediateQueue = Trampoline.makeQueue()
-      ec.execute(new ResumeRun(head, rest, ec, trampolineForResume()))
+      if (ec.isImmediate) {
+        immediateLoop(head, ec)
+      } else {
+        forkTheRest(head, ec)
+      }
     }
+  }
+
+  private def forkTheRest(head: Runnable, ec: TrampolineEC): Unit = {
+    val rest = immediateQueue.shallowCopy()
+    immediateQueue = Trampoline.makeQueue()
+    ec.execute(new ResumeRun(head, rest, ec, trampolineForResume()))
   }
 
   /**
@@ -72,12 +80,12 @@ private[execution] class Trampoline(
     fallbackTrampoline.getOrElse(() => this)
 
   @tailrec
-  private final def immediateLoop(task: Runnable, ec: ExecutionContext): Unit = {
+  private final def immediateLoop(task: Runnable, ec: TrampolineEC): Unit = {
     try {
       task.run()
     } catch {
       case ex: Throwable =>
-        forkTheRest(ec)
+        continueExecution(ec)
         if (NonFatal(ex)) ec.reportFailure(ex)
         else throw ex
     }
@@ -86,12 +94,12 @@ private[execution] class Trampoline(
     if (next ne null) immediateLoop(next, ec)
   }
 
-  protected final def trampolineContext(parentContext: BlockContext, ec: ExecutionContext): BlockContext =
+  protected final def trampolineContext(parentContext: BlockContext, ec: TrampolineEC): BlockContext =
     new BlockContext {
       def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
         // In case of blocking, execute all scheduled local tasks on
         // a separate thread, otherwise we could end up with a dead-lock
-        forkTheRest(ec)
+        continueExecution(ec)
         if (parentContext ne null) {
           parentContext.blockOn(thunk)
         } else {
@@ -101,18 +109,47 @@ private[execution] class Trampoline(
     }
 }
 
-object Trampoline {
-  final class ResumeRun(
+private[execution] object Trampoline {
+
+  /** ExecutionContext backing the [[Trampoline]]. */
+  trait TrampolineEC {
+    def execute(runnable: Runnable): Unit
+    def reportFailure(e: Throwable): Unit
+    def isImmediate: Boolean
+  }
+
+  /** Forking ExecutionContext backing the [[Trampoline]]. */
+  trait ForkingEC extends TrampolineEC {
+    def isImmediate: Boolean = false
+  }
+
+  final case class ForkingECImpl(ec: ExecutionContext) extends ForkingEC {
+    override def execute(runnable: Runnable): Unit = ec.execute(runnable)
+    override def reportFailure(e: Throwable): Unit = ec.reportFailure(e)
+  }
+
+  /** Immediate ExecutionContext that executes everything on the current thread.
+   *  Used for optimization of the run loop.
+   */
+  object ImmediateEC extends TrampolineEC {
+    override def execute(runnable: Runnable): Unit = runnable.run()
+    override def reportFailure(e: Throwable): Unit = throw e
+    override def isImmediate: Boolean = true
+  }
+
+  private final class ResumeRun(
     head: Runnable,
     rest: ChunkedArrayQueue[Runnable],
-    ec: ExecutionContext,
+    ec: TrampolineEC,
     fallbackTrampoline: () => Trampoline,
   ) extends Runnable {
 
     def run(): Unit = {
       val trampoline = fallbackTrampoline()
       trampoline.enqueueAll(rest)
-      trampoline.startLoop(head, ec)
+      // Underlying Ec might have scheduled ResumeRun to execute on the same thread, we still need to check if we're
+      // already in the loop - thus execute.
+      trampoline.execute(head, ec)
     }
   }
 

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -25,8 +25,9 @@ import scala.concurrent.{BlockContext, CanAwait, ExecutionContext}
 import scala.util.control.NonFatal
 
 private[execution] class Trampoline(
-  private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue(),
+  private[this] val fallbackTrampoline: Option[() => Trampoline] = None,
 ) {
+  private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue()
   private[this] var withinLoop: Boolean = false
 
   def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
@@ -45,14 +46,30 @@ private[execution] class Trampoline(
     }
   }
 
+  final def enqueueAll(chunkedArrayQueue: ChunkedArrayQueue[Runnable]): Unit =
+    immediateQueue.enqueueAll(chunkedArrayQueue)
+
   private def forkTheRest(ec: ExecutionContext): Unit = {
     val head = immediateQueue.dequeue()
     if (head ne null) {
       val rest = immediateQueue.shallowCopy()
       immediateQueue = Trampoline.makeQueue()
-      ec.execute(new ResumeRun(head, rest, ec))
+      ec.execute(new ResumeRun(head, rest, ec, trampolineForResume()))
     }
   }
+
+  /**
+   * Computation should resume on a trampoline.
+   *
+   * In a multithreaded environment (JVM) it should be a thread-local trampoline of the thread that resumes the
+   * computation. Using trampoline of the previous thread is unsafe because it might lead to concurrent modification
+   * of the underlying [[ChunkedArrayQueue]], which is not thread-safe - at that point the previous thread
+   * might have already entered another run loop.
+   *
+   * In a singlethreaded environment (SJS) computation will resume on the same trampoline.
+   */
+  private def trampolineForResume() =
+    fallbackTrampoline.getOrElse(() => this)
 
   @tailrec
   private final def immediateLoop(task: Runnable, ec: ExecutionContext): Unit = {
@@ -85,9 +102,18 @@ private[execution] class Trampoline(
 }
 
 object Trampoline {
-  final class ResumeRun(head: Runnable, rest: ChunkedArrayQueue[Runnable], ec: ExecutionContext) extends Runnable {
+  final class ResumeRun(
+    head: Runnable,
+    rest: ChunkedArrayQueue[Runnable],
+    ec: ExecutionContext,
+    fallbackTrampoline: () => Trampoline,
+  ) extends Runnable {
 
-    def run(): Unit = new Trampoline(rest).immediateLoop(head, ec)
+    def run(): Unit = {
+      val trampoline = fallbackTrampoline()
+      trampoline.enqueueAll(rest)
+      trampoline.startLoop(head, ec)
+    }
   }
 
   private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -17,6 +17,7 @@
 
 package monix.execution.internal
 
+import monix.execution.internal.Trampoline.ResumeRun
 import monix.execution.internal.collection.ChunkedArrayQueue
 
 import scala.annotation.tailrec
@@ -25,7 +26,7 @@ import scala.util.control.NonFatal
 
 private[execution] class Trampoline(
   private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue(),
-  private[this] val isForked: Boolean = false
+  private[this] val isForked: Boolean = false,
 ) {
   private[this] var withinLoop: Boolean = false
 
@@ -46,20 +47,15 @@ private[execution] class Trampoline(
   }
 
   private def forkTheRest(ec: ExecutionContext): Unit = {
-    final class ResumeRun(head: Runnable, rest: ChunkedArrayQueue[Runnable]) extends Runnable {
-
-      def run(): Unit = new Trampoline(rest, isForked = true).startLoop(head, ec)
-    }
-
     val head = immediateQueue.dequeue()
     if (head ne null) {
       val rest = immediateQueue.shallowCopy()
       if (!isForked) {
-        // forked Trampoline is one-time use and will get discarded,
+        // forked Trampoline is of one-time use and will get discarded,
         // no need to maintain the state here
         immediateQueue = Trampoline.makeQueue()
       }
-      ec.execute(new ResumeRun(head, rest))
+      ec.execute(new ResumeRun(head, rest, ec))
     }
   }
 
@@ -94,5 +90,10 @@ private[execution] class Trampoline(
 }
 
 object Trampoline {
+  final class ResumeRun(head: Runnable, rest: ChunkedArrayQueue[Runnable], ec: ExecutionContext) extends Runnable {
+
+    def run(): Unit = new Trampoline(rest, isForked = true).immediateLoop(head, ec)
+  }
+
   private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -23,10 +23,11 @@ import scala.annotation.tailrec
 import scala.concurrent.{BlockContext, CanAwait, ExecutionContext}
 import scala.util.control.NonFatal
 
-private[execution] class Trampoline {
-  private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)
-  private[this] var immediateQueue = makeQueue()
-  private[this] var withinLoop = false
+private[execution] class Trampoline(
+  private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue(),
+  private[this] val isForked: Boolean = false
+) {
+  private[this] var withinLoop: Boolean = false
 
   def startLoop(runnable: Runnable, ec: ExecutionContext): Unit = {
     withinLoop = true
@@ -44,19 +45,20 @@ private[execution] class Trampoline {
     }
   }
 
-  protected final def forkTheRest(ec: ExecutionContext): Unit = {
+  private def forkTheRest(ec: ExecutionContext): Unit = {
     final class ResumeRun(head: Runnable, rest: ChunkedArrayQueue[Runnable]) extends Runnable {
 
-      def run(): Unit = {
-        immediateQueue.enqueueAll(rest)
-        immediateLoop(head, ec)
-      }
+      def run(): Unit = new Trampoline(rest, isForked = true).startLoop(head, ec)
     }
 
     val head = immediateQueue.dequeue()
     if (head ne null) {
       val rest = immediateQueue.shallowCopy()
-      immediateQueue = makeQueue()
+      if (!isForked) {
+        // forked Trampoline is one-time use and will get discarded,
+        // no need to maintain the state here
+        immediateQueue = Trampoline.makeQueue()
+      }
       ec.execute(new ResumeRun(head, rest))
     }
   }
@@ -89,4 +91,8 @@ private[execution] class Trampoline {
         }
       }
     }
+}
+
+object Trampoline {
+  private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/Trampoline.scala
@@ -26,7 +26,6 @@ import scala.util.control.NonFatal
 
 private[execution] class Trampoline(
   private[this] var immediateQueue: ChunkedArrayQueue[Runnable] = Trampoline.makeQueue(),
-  private[this] val isForked: Boolean = false,
 ) {
   private[this] var withinLoop: Boolean = false
 
@@ -50,11 +49,7 @@ private[execution] class Trampoline(
     val head = immediateQueue.dequeue()
     if (head ne null) {
       val rest = immediateQueue.shallowCopy()
-      if (!isForked) {
-        // forked Trampoline is of one-time use and will get discarded,
-        // no need to maintain the state here
-        immediateQueue = Trampoline.makeQueue()
-      }
+      immediateQueue = Trampoline.makeQueue()
       ec.execute(new ResumeRun(head, rest, ec))
     }
   }
@@ -92,7 +87,7 @@ private[execution] class Trampoline(
 object Trampoline {
   final class ResumeRun(head: Runnable, rest: ChunkedArrayQueue[Runnable], ec: ExecutionContext) extends Runnable {
 
-    def run(): Unit = new Trampoline(rest, isForked = true).immediateLoop(head, ec)
+    def run(): Unit = new Trampoline(rest).immediateLoop(head, ec)
   }
 
   private def makeQueue(): ChunkedArrayQueue[Runnable] = ChunkedArrayQueue[Runnable](chunkSize = 16)

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -18,20 +18,17 @@
 package monix.execution.internal
 package collection
 
-import java.util.concurrent.atomic.AtomicReferenceArray
-
 private[monix] final class ChunkedArrayQueue[A] private (
-  initialTailArray: AtomicReferenceArray[AnyRef],
+  initialTailArray: Array[AnyRef],
   initialTailIndex: Int,
-  initialHeadArray: AtomicReferenceArray[AnyRef],
+  initialHeadArray: Array[AnyRef],
   initialHeadIndex: Int,
-  chunkSize: Int,
-) extends Serializable { self =>
+  chunkSize: Int)
+  extends Serializable { self =>
 
   assert(chunkSize > 1, "chunkSize > 1")
 
   private[this] val modulo = chunkSize - 1
-  private[this] val lastElementIndex = chunkSize - 2
   private[this] var tailArray = initialTailArray
   private[this] var tailIndex = initialTailIndex
   private[this] var headArray = initialHeadArray
@@ -48,15 +45,14 @@ private[monix] final class ChunkedArrayQueue[A] private (
     * Enqueues an item on the queue.
     */
   def enqueue(a: A): Unit = {
-    tailArray.set(tailIndex, a.asInstanceOf[AnyRef])
+    tailArray(tailIndex) = a.asInstanceOf[AnyRef]
+    tailIndex += 1
 
-    if (tailIndex == lastElementIndex) {
-      val newArray = new AtomicReferenceArray[AnyRef](chunkSize)
-      tailArray.set(modulo, newArray)
+    if (tailIndex == modulo) {
+      val newArray = new Array[AnyRef](chunkSize)
+      tailArray(tailIndex) = newArray
       tailArray = newArray
       tailIndex = 0
-    } else {
-      tailIndex += 1
     }
   }
 
@@ -74,13 +70,13 @@ private[monix] final class ChunkedArrayQueue[A] private (
     */
   def dequeue(): A = {
     if ((headArray ne tailArray) || headIndex < tailIndex) {
-      val result = headArray.getAndSet(headIndex, null).asInstanceOf[A]
+      val result = headArray(headIndex).asInstanceOf[A]
+      headArray(headIndex) = null
+      headIndex += 1
 
-      if (headIndex == lastElementIndex) {
-        headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
+      if (headIndex == modulo) {
+        headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
         headIndex = 0
-      } else {
-        headIndex += 1
       }
       result
     } else {
@@ -101,24 +97,16 @@ private[monix] final class ChunkedArrayQueue[A] private (
       }
 
       def next(): A = {
-        val result = headArray.get(headIndex).asInstanceOf[A]
+        val result = headArray(headIndex).asInstanceOf[A]
+        headIndex += 1
 
-        if (headIndex == lastElementIndex) {
-          headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
+        if (headIndex == modulo) {
+          headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
           headIndex = 0
-        } else {
-          headIndex += 1
         }
         result
       }
     }
-
-  /**
-   * Needed when passing the queue to another thread. Otherwise, changes applied to the queue since its creation
-   * might not be visible to the other thread.
-   */
-  def shallowCopy(): ChunkedArrayQueue[A] =
-    new ChunkedArrayQueue[A](tailArray, tailIndex, headArray, headIndex, chunkSize)
 }
 
 private[monix] object ChunkedArrayQueue {
@@ -126,7 +114,7 @@ private[monix] object ChunkedArrayQueue {
     * Builds a new [[ChunkedArrayQueue]].
     */
   def apply[A](chunkSize: Int = 8): ChunkedArrayQueue[A] = {
-    val arr = new AtomicReferenceArray[AnyRef](chunkSize)
+    val arr = new Array[AnyRef](chunkSize)
     new ChunkedArrayQueue[A](arr, 0, arr, 0, chunkSize)
   }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -18,17 +18,20 @@
 package monix.execution.internal
 package collection
 
+import java.util.concurrent.atomic.AtomicReferenceArray
+
 private[monix] final class ChunkedArrayQueue[A] private (
-  initialTailArray: Array[AnyRef],
+  initialTailArray: AtomicReferenceArray[AnyRef],
   initialTailIndex: Int,
-  initialHeadArray: Array[AnyRef],
+  initialHeadArray: AtomicReferenceArray[AnyRef],
   initialHeadIndex: Int,
-  chunkSize: Int)
-  extends Serializable { self =>
+  chunkSize: Int,
+) extends Serializable { self =>
 
   assert(chunkSize > 1, "chunkSize > 1")
 
   private[this] val modulo = chunkSize - 1
+  private[this] val lastElementIndex = chunkSize - 2
   private[this] var tailArray = initialTailArray
   private[this] var tailIndex = initialTailIndex
   private[this] var headArray = initialHeadArray
@@ -45,14 +48,15 @@ private[monix] final class ChunkedArrayQueue[A] private (
     * Enqueues an item on the queue.
     */
   def enqueue(a: A): Unit = {
-    tailArray(tailIndex) = a.asInstanceOf[AnyRef]
-    tailIndex += 1
+    tailArray.set(tailIndex, a.asInstanceOf[AnyRef])
 
-    if (tailIndex == modulo) {
-      val newArray = new Array[AnyRef](chunkSize)
-      tailArray(tailIndex) = newArray
+    if (tailIndex == lastElementIndex) {
+      val newArray = new AtomicReferenceArray[AnyRef](chunkSize)
+      tailArray.set(modulo, newArray)
       tailArray = newArray
       tailIndex = 0
+    } else {
+      tailIndex += 1
     }
   }
 
@@ -75,13 +79,13 @@ private[monix] final class ChunkedArrayQueue[A] private (
     */
   def dequeue(): A = {
     if ((headArray ne tailArray) || headIndex < tailIndex) {
-      val result = headArray(headIndex).asInstanceOf[A]
-      headArray(headIndex) = null
-      headIndex += 1
+      val result = headArray.getAndSet(headIndex, null).asInstanceOf[A]
 
-      if (headIndex == modulo) {
-        headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
+      if (headIndex == lastElementIndex) {
+        headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
         headIndex = 0
+      } else {
+        headIndex += 1
       }
       result
     } else {
@@ -102,16 +106,20 @@ private[monix] final class ChunkedArrayQueue[A] private (
       }
 
       def next(): A = {
-        val result = headArray(headIndex).asInstanceOf[A]
-        headIndex += 1
+        val result = headArray.get(headIndex).asInstanceOf[A]
 
-        if (headIndex == modulo) {
-          headArray = headArray(modulo).asInstanceOf[Array[AnyRef]]
+        if (headIndex == lastElementIndex) {
+          headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
           headIndex = 0
+        } else {
+          headIndex += 1
         }
         result
       }
     }
+
+  def shallowCopy(): ChunkedArrayQueue[A] =
+    new ChunkedArrayQueue[A](tailArray, tailIndex, headArray, headIndex, chunkSize)
 }
 
 private[monix] object ChunkedArrayQueue {
@@ -119,7 +127,7 @@ private[monix] object ChunkedArrayQueue {
     * Builds a new [[ChunkedArrayQueue]].
     */
   def apply[A](chunkSize: Int = 8): ChunkedArrayQueue[A] = {
-    val arr = new Array[AnyRef](chunkSize)
+    val arr = new AtomicReferenceArray[AnyRef](chunkSize)
     new ChunkedArrayQueue[A](arr, 0, arr, 0, chunkSize)
   }
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -60,6 +60,15 @@ private[monix] final class ChunkedArrayQueue[A] private (
     }
   }
 
+  /** Pushes an entire iterator on the stack. */
+  def enqueueAll(cursor: Iterator[A]): Unit = {
+    while (cursor.hasNext) enqueue(cursor.next())
+  }
+
+  /** Pushes an entire sequence on the stack. */
+  def enqueueAll(stack: ChunkedArrayQueue[A]): Unit =
+    enqueueAll(stack.iterator)
+
   /**
     * Pops an item from the queue, FIFO order.
     */
@@ -79,6 +88,35 @@ private[monix] final class ChunkedArrayQueue[A] private (
     }
   }
 
+  /** Builds an iterator out of this queue. */
+  def iterator: Iterator[A] =
+    new Iterator[A] {
+      private[this] var headArray = self.headArray
+      private[this] var headIndex = self.headIndex
+      private[this] val tailArray = self.tailArray
+      private[this] val tailIndex = self.tailIndex
+
+      def hasNext: Boolean = {
+        (headArray ne tailArray) || headIndex < tailIndex
+      }
+
+      def next(): A = {
+        val result = headArray.get(headIndex).asInstanceOf[A]
+
+        if (headIndex == lastElementIndex) {
+          headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
+          headIndex = 0
+        } else {
+          headIndex += 1
+        }
+        result
+      }
+    }
+
+  /**
+   * Needed when passing the queue to another thread. Otherwise, changes applied to the queue since its creation
+   * might not be visible to the other thread.
+   */
   def shallowCopy(): ChunkedArrayQueue[A] =
     new ChunkedArrayQueue[A](tailArray, tailIndex, headArray, headIndex, chunkSize)
 }

--- a/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/internal/collection/ChunkedArrayQueue.scala
@@ -60,20 +60,6 @@ private[monix] final class ChunkedArrayQueue[A] private (
     }
   }
 
-  /** Pushes an entire iterator on the stack. */
-  def enqueueAll(cursor: Iterator[A]): Unit = {
-    while (cursor.hasNext) enqueue(cursor.next())
-  }
-
-  /** Pushes an entire sequence on the stack. */
-  def enqueueAll(seq: Iterable[A]): Unit = {
-    enqueueAll(seq.iterator)
-  }
-
-  /** Pushes an entire sequence on the stack. */
-  def enqueueAll(stack: ChunkedArrayQueue[A]): Unit =
-    enqueueAll(stack.iterator)
-
   /**
     * Pops an item from the queue, FIFO order.
     */
@@ -92,31 +78,6 @@ private[monix] final class ChunkedArrayQueue[A] private (
       null.asInstanceOf[A]
     }
   }
-
-  /** Builds an iterator out of this queue. */
-  def iterator: Iterator[A] =
-    new Iterator[A] {
-      private[this] var headArray = self.headArray
-      private[this] var headIndex = self.headIndex
-      private[this] val tailArray = self.tailArray
-      private[this] val tailIndex = self.tailIndex
-
-      def hasNext: Boolean = {
-        (headArray ne tailArray) || headIndex < tailIndex
-      }
-
-      def next(): A = {
-        val result = headArray.get(headIndex).asInstanceOf[A]
-
-        if (headIndex == lastElementIndex) {
-          headArray = headArray.get(modulo).asInstanceOf[AtomicReferenceArray[AnyRef]]
-          headIndex = 0
-        } else {
-          headIndex += 1
-        }
-        result
-      }
-    }
 
   def shallowCopy(): ChunkedArrayQueue[A] =
     new ChunkedArrayQueue[A](tailArray, tailIndex, headArray, headIndex, chunkSize)

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
@@ -19,6 +19,8 @@ package monix.execution.internal.collection
 
 import minitest.SimpleTestSuite
 
+import scala.collection.immutable.Queue
+
 object ChunkedArrayQueueSuite extends SimpleTestSuite {
   test("enqueue and dequeue 8 items") {
     val queue = ChunkedArrayQueue[Int](chunkSize = 8)
@@ -72,5 +74,34 @@ object ChunkedArrayQueueSuite extends SimpleTestSuite {
       assertEquals(queue.dequeue().asInstanceOf[Int], i)
       assertEquals(queue.dequeue(), null)
     }
+  }
+
+  test("enqueueAll(queue)") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    val queue2 = ChunkedArrayQueue[Int](chunkSize = 8)
+
+    for (i <- 0 until 100) queue2.enqueue(i)
+    queue.enqueueAll(queue2)
+
+    var list = Queue.empty[Int]
+    while (!queue.isEmpty) {
+      assert(!queue.isEmpty)
+      list = list.enqueue(queue.dequeue())
+    }
+
+    assertEquals(list.toList, (0 until 100).toList)
+    assertEquals(queue.dequeue(), null)
+    assert(queue.isEmpty, "queue.isEmpty")
+    assert(!queue2.isEmpty, "!stack2.isEmpty")
+  }
+
+  test("iterator") {
+    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
+    val expected = (0 until 100).toList
+    for (i <- expected) queue.enqueue(i)
+
+    assertEquals(queue.dequeue(), 0)
+    assertEquals(queue.dequeue(), 1)
+    assertEquals(queue.iterator.toList, expected.drop(2))
   }
 }

--- a/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/internal/collection/ChunkedArrayQueueSuite.scala
@@ -18,7 +18,6 @@
 package monix.execution.internal.collection
 
 import minitest.SimpleTestSuite
-import scala.collection.immutable.Queue
 
 object ChunkedArrayQueueSuite extends SimpleTestSuite {
   test("enqueue and dequeue 8 items") {
@@ -73,50 +72,5 @@ object ChunkedArrayQueueSuite extends SimpleTestSuite {
       assertEquals(queue.dequeue().asInstanceOf[Int], i)
       assertEquals(queue.dequeue(), null)
     }
-  }
-
-  test("enqueueAll(queue)") {
-    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
-    val queue2 = ChunkedArrayQueue[Int](chunkSize = 8)
-
-    for (i <- 0 until 100) queue2.enqueue(i)
-    queue.enqueueAll(queue2)
-
-    var list = Queue.empty[Int]
-    while (!queue.isEmpty) {
-      assert(!queue.isEmpty)
-      list = list.enqueue(queue.dequeue())
-    }
-
-    assertEquals(list.toList, (0 until 100).toList)
-    assertEquals(queue.dequeue(), null)
-    assert(queue.isEmpty, "queue.isEmpty")
-    assert(!queue2.isEmpty, "!stack2.isEmpty")
-  }
-
-  test("enqueueAll(iterable)") {
-    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
-    val expected = (0 until 100).toList
-    queue.enqueueAll(expected)
-
-    var list = Queue.empty[Int]
-    while (!queue.isEmpty) {
-      assert(!queue.isEmpty)
-      list = list.enqueue(queue.dequeue())
-    }
-
-    assertEquals(list.toList, expected)
-    assertEquals(queue.dequeue(), null)
-    assert(queue.isEmpty, "queue.isEmpty")
-  }
-
-  test("iterator") {
-    val queue = ChunkedArrayQueue[Int](chunkSize = 8)
-    val expected = (0 until 100).toList
-    for (i <- expected) queue.enqueue(i)
-
-    assertEquals(queue.dequeue(), 0)
-    assertEquals(queue.dequeue(), 1)
-    assertEquals(queue.iterator.toList, expected.drop(2))
   }
 }


### PR DESCRIPTION
Forked executions of Trampoline tasks operated on the same data structures as the thread-local Trampoline. Consequently, multiple threads were able to concurrently access same non-thread-safe resources.

Fixed by operating solely on copied data in the forked Trampoline instead of referencing the previous-thread-local Trampoline.