### PR TITLE
JDK 17+ compatibility: JCTools 4.x, suppress deprecation warnings, expand CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11 ]
+        java: [ 11, 17, 21, 25 ]
         # WARN: build.sbt depends on this key path, as scalaVersion and
         # crossScalaVersions is determined from it
         scala: [ 2.13.18, 3.3.7 ]

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
+import MonixBuildUtils.*
+import org.typelevel.scalacoptions.ScalacOptions
 import sbt.Keys.version
-import sbt.{ Def, Global, Tags }
+import sbt.{Def, Global, Tags}
 
 import scala.collection.immutable.SortedSet
-import MonixBuildUtils._
-import org.typelevel.scalacoptions.ScalacOptions
 
 val benchmarkProjects = List(
   "benchmarksPrev",
@@ -27,7 +27,7 @@ addCommandAlias("ci-release", ";+publishSigned ;sonatypeBundleRelease")
 val cats_Version              = "2.7.0"
 val catsEffect_Version        = "2.5.5"
 val fs2_Version               = "2.5.11"
-val jcTools_Version           = "3.3.0"
+val jcTools_Version           = "4.0.5"
 val reactiveStreams_Version   = "1.0.4"
 val macrotaskExecutor_Version = "1.0.0"
 val minitest_Version          = "2.9.6"
@@ -191,7 +191,7 @@ lazy val sharedSettings = pgpSettings ++ Seq(
     "-Ywarn-unused:params",
     "-Wunused:params",
     "-Xlint:infer-any",
-    "-Wnonunit-statement"
+    "-Wnonunit-statement",
   ),
   // Disabled from tpolecat for test compilation:
   // -Wunused:patvars triggers on for-comprehension loop vars in tests (pre-existing pattern)
@@ -205,6 +205,8 @@ lazy val sharedSettings = pgpSettings ++ Seq(
   },
   // Turning off fatal warnings for doc generation
   Compile / doc / tpolecatExcludeOptions ++= ScalacOptions.defaultConsoleExclude,
+  // Silence "unused @nowarn" —Thread#getId on JDK11
+  Compile / scalacOptions ++= Seq("-Wconf:cat=unused-nowarn:s"),
   // Silence everything in auto-generated files
   scalacOptions ++= {
     if (isDotty.value)

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/Platform.scala
@@ -18,6 +18,8 @@
 package monix.execution.internal
 
 import monix.execution.schedulers.CanBlock
+
+import scala.annotation.nowarn
 import scala.concurrent.{Await, Awaitable}
 import scala.concurrent.duration.Duration
 import scala.util.Try
@@ -175,6 +177,7 @@ private[monix] object Platform {
     * To be used for multi-threading optimizations. Note that
     * in JavaScript this always returns the same value.
     */
+  @nowarn("msg=deprecated")
   def currentThreadId(): Long = {
     Thread.currentThread().getId
   }

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromCircularQueue.scala
@@ -23,6 +23,8 @@ import monix.execution.internal.atomic.UnsafeAccess
 import monix.execution.internal.collection.LowLevelConcurrentQueue
 import monix.execution.internal.jctools.queues.MessagePassingQueue
 import sun.misc.Unsafe
+
+import scala.annotation.nowarn
 import scala.collection.mutable
 
 private[internal] abstract class FromCircularQueue[A](queue: MessagePassingQueue[A])
@@ -50,6 +52,7 @@ private[internal] abstract class FromCircularQueue[A](queue: MessagePassingQueue
   }
 }
 
+@nowarn("msg=deprecated")
 private[internal] object FromCircularQueue {
   /**
     * Builds a [[FromCircularQueue]] instance.

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/collection/queues/FromMessagePassingQueue.scala
@@ -23,6 +23,8 @@ import monix.execution.internal.atomic.UnsafeAccess
 import monix.execution.internal.collection.LowLevelConcurrentQueue
 import monix.execution.internal.jctools.queues.MessagePassingQueue
 import sun.misc.Unsafe
+
+import scala.annotation.nowarn
 import scala.collection.mutable
 
 private[internal] abstract class FromMessagePassingQueue[A](queue: MessagePassingQueue[A])
@@ -47,6 +49,7 @@ private[internal] abstract class FromMessagePassingQueue[A](queue: MessagePassin
   }
 }
 
+@nowarn("msg=deprecated")
 private[internal] object FromMessagePassingQueue {
   /**
     * Builds a [[FromMessagePassingQueue]] instance.

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/DynamicWorkerThreadFactory.scala
@@ -19,20 +19,21 @@ package monix.execution.internal.forkJoin
 
 import java.util.concurrent.ForkJoinPool.{ForkJoinWorkerThreadFactory, ManagedBlocker}
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread, ThreadFactory}
-
 import monix.execution.internal.forkJoin.DynamicWorkerThreadFactory.EmptyBlockContext
 
+import scala.annotation.nowarn
 import scala.concurrent.{BlockContext, CanAwait}
 
 // Implement BlockContext on FJP threads
 private[monix] final class DynamicWorkerThreadFactory(
   prefix: String,
   uncaught: Thread.UncaughtExceptionHandler,
-  daemonic: Boolean)
-  extends ThreadFactory with ForkJoinWorkerThreadFactory {
+  daemonic: Boolean
+) extends ThreadFactory with ForkJoinWorkerThreadFactory {
 
   require(prefix ne null, "DefaultWorkerThreadFactory.prefix must be non null")
 
+  @nowarn("msg=deprecated")
   def wire[T <: Thread](thread: T): T = {
     thread.setDaemon(daemonic)
     thread.setUncaughtExceptionHandler(uncaught)

--- a/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/internal/forkJoin/StandardWorkerThreadFactory.scala
@@ -20,12 +20,15 @@ package monix.execution.internal.forkJoin
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory
 import java.util.concurrent.{ForkJoinPool, ForkJoinWorkerThread, ThreadFactory}
 
+import scala.annotation.nowarn
+
 private[monix] final class StandardWorkerThreadFactory(
   prefix: String,
   uncaught: Thread.UncaughtExceptionHandler,
-  daemonic: Boolean)
-  extends ThreadFactory with ForkJoinWorkerThreadFactory {
+  daemonic: Boolean
+) extends ThreadFactory with ForkJoinWorkerThreadFactory {
 
+  @nowarn("msg=deprecated")
   def wire[T <: Thread](thread: T): T = {
     thread.setDaemon(daemonic)
     thread.setUncaughtExceptionHandler(uncaught)

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -100,6 +100,13 @@ object ExecutorScheduler {
     // Implementations will inherit BatchingScheduler, so this is guaranteed
     val ft = features + Scheduler.BATCHING
     service match {
+      case _: ForkJoinPool =>
+        // ForkJoinPool implements ScheduledExecutorService since JDK 25,
+        // but its scheduling behavior differs from ScheduledThreadPoolExecutor
+        // (e.g. exception handling in scheduled tasks). Use the simple executor
+        // path with Monix's own ScheduledExecutorService for reliable scheduling.
+        val s = Defaults.scheduledExecutor
+        new FromSimpleExecutor(s, service, reporter, executionModel, ft)
       case ref: ScheduledExecutorService =>
         new FromScheduledExecutor(ref, reporter, executionModel, ft)
       case _ =>

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -100,13 +100,6 @@ object ExecutorScheduler {
     // Implementations will inherit BatchingScheduler, so this is guaranteed
     val ft = features + Scheduler.BATCHING
     service match {
-      case _: ForkJoinPool =>
-        // ForkJoinPool implements ScheduledExecutorService since JDK 25,
-        // but its scheduling behavior differs from ScheduledThreadPoolExecutor
-        // (e.g. exception handling in scheduled tasks). Use the simple executor
-        // path with Monix's own ScheduledExecutorService for reliable scheduling.
-        val s = Defaults.scheduledExecutor
-        new FromSimpleExecutor(s, service, reporter, executionModel, ft)
       case ref: ScheduledExecutorService =>
         new FromScheduledExecutor(ref, reporter, executionModel, ft)
       case _ =>

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ThreadFactoryBuilder.scala
@@ -17,8 +17,10 @@
 
 package monix.execution.schedulers
 
-import java.util.concurrent.ThreadFactory
 import monix.execution.UncaughtExceptionReporter
+
+import java.util.concurrent.ThreadFactory
+import scala.annotation.nowarn
 
 private[schedulers] object ThreadFactoryBuilder {
   /** Constructs a ThreadFactory using the provided name prefix and appending
@@ -28,8 +30,10 @@ private[schedulers] object ThreadFactoryBuilder {
     * @param daemonic specifies whether the created threads should be daemonic
     *                 (non-daemonic threads are blocking the JVM process on exit).
     */
+
   def apply(name: String, reporter: UncaughtExceptionReporter, daemonic: Boolean): ThreadFactory = {
     new ThreadFactory {
+      @nowarn("msg=deprecated")
       def newThread(r: Runnable) = {
         val thread = new Thread(r)
         thread.setName(name + "-" + thread.getId)


### PR DESCRIPTION
## Summary

### Dependencies
- **JCTools** 3.3.0 → 4.0.5

### CI
- Expand JVM test matrix: Java 11 → Java 11, 17, 21, 25

### Deprecation suppressions
Add `@nowarn("msg=deprecated")` to suppress warnings that appear on newer JDKs but are absent on JDK 11:
- `Thread.getId` (deprecated since JDK 19) — `Platform`, `DynamicWorkerThreadFactory`, `StandardWorkerThreadFactory`, `ThreadFactoryBuilder`
- `sun.misc.Unsafe` — `FromMessagePassingQueue`, `FromCircularQueue`
- `-Wconf:cat=unused-nowarn:s` in `build.sbt` to prevent the above `@nowarn` annotations from being flagged as unused on JDK 11

## Test plan
- [ ] CI green on Java 11, 17, 21, 25
- [ ] `sbt +compile` passes on all Scala versions
- [ ] `sbt +test` passes (JVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)