### PR TITLE
Drop Java 8 from CI and increase JVM memory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11 ]
+        java: [ 11 ]
         # WARN: build.sbt depends on this key path, as scalaVersion and
         # crossScalaVersions is determined from it
         scala: [ 2.13.8, 3.1.2 ]
@@ -65,8 +65,8 @@ jobs:
         # WARN: build.sbt depends on this key path, as scalaVersion and
         # crossScalaVersions is determined from it
         include:
-          - { java: 8, scala: 2.13.8 }
-          - { java: 8, scala: 3.1.2 }
+          - { java: 11, scala: 2.13.8 }
+          - { java: 11, scala: 3.1.2 }
 
     env:
       CI: true
@@ -118,8 +118,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java: 8, scala: 2.13.8 }
-          - { java: 8, scala: 3.1.2 }
+          - { java: 11, scala: 2.13.8 }
+          - { java: 11, scala: 3.1.2 }
 
     steps:
       - uses: actions/checkout@v4
@@ -162,9 +162,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java: 8, scala: 2.13.8 }
+          - { java: 11, scala: 2.13.8 }
           # TODO: enable this after it works!
-          # - { java: 8, scala: 3.1.2 }
+          # - { java: 11, scala: 3.1.2 }
 
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +223,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - uses: sbt/setup-sbt@v1
 
       - name: Install GnuPG2

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 11
       - uses: sbt/setup-sbt@v1
 
       - name: Install GnuPG2

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,6 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx3G
+-Xmx8G
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit


### PR DESCRIPTION
## Summary
- Remove Java 8 from the GitHub Actions build matrix, making Java 11 the minimum CI version
- Increase JVM max heap from 3G to 8G in `.jvmopts`

## Test plan
- [ ] Verify CI passes on Java 11 for all Scala versions (2.13.8, 3.1.2)
- [ ] Confirm no jobs reference Java 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)