### PR TITLE
Fix error reporting in Schedulers

### DIFF
--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedScheduledThreadPoolExecutor.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/AdaptedScheduledThreadPoolExecutor.scala
@@ -17,14 +17,18 @@
 
 package monix.execution.schedulers
 
+import monix.execution.UncaughtExceptionReporter
+
 import java.util.concurrent._
 
 /** A mixin for adapting for the Java `ThreadPoolExecutor` implementation
   * to report errors using the default thread exception handler.
   */
-private[schedulers] abstract class AdaptedThreadPoolExecutor(corePoolSize: Int, factory: ThreadFactory)
-  extends ScheduledThreadPoolExecutor(corePoolSize, factory) {
-  def reportFailure(t: Throwable): Unit
+private[schedulers] final class AdaptedScheduledThreadPoolExecutor(
+  corePoolSize: Int,
+  factory: ThreadFactory,
+  reporter: UncaughtExceptionReporter,
+) extends ScheduledThreadPoolExecutor(corePoolSize, factory) {
 
   override def afterExecute(r: Runnable, t: Throwable): Unit = {
     super.afterExecute(r, t)
@@ -45,6 +49,9 @@ private[schedulers] abstract class AdaptedThreadPoolExecutor(corePoolSize: Int, 
       }
     }
 
-    if (exception ne null) reportFailure(exception)
+    if (exception ne null) reporter.reportFailure(exception)
   }
+
+  def withUncaughtExceptionReporter(reporter: UncaughtExceptionReporter): AdaptedScheduledThreadPoolExecutor =
+    new AdaptedScheduledThreadPoolExecutor(corePoolSize, factory, reporter)
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -17,15 +17,16 @@
 
 package monix.execution.schedulers
 
-import java.util.concurrent.{ExecutorService, ForkJoinPool, ScheduledExecutorService}
 import monix.execution.internal.forkJoin.{AdaptedForkJoinPool, DynamicWorkerThreadFactory, StandardWorkerThreadFactory}
 import monix.execution.internal.{InterceptRunnable, Platform, ScheduledExecutors}
-import monix.execution.{Cancelable, UncaughtExceptionReporter}
-import monix.execution.{Features, Scheduler}
+import monix.execution.{Cancelable, Features, Scheduler, UncaughtExceptionReporter}
+
+import java.util.concurrent.{ExecutorService, ScheduledExecutorService}
 // Prevents conflict with the deprecated symbol
 import monix.execution.{ExecutionModel => ExecModel}
-import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
+
 import scala.concurrent.duration.TimeUnit
+import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
 import scala.util.control.NonFatal
 
 /** An [[ExecutorScheduler]] is a class for building a
@@ -54,9 +55,10 @@ abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporte
     awaitOn.execute(new Runnable {
       override def run() =
         try blocking {
-          p.success(e.awaitTermination(timeout, unit))
-          ()
-        } catch {
+            p.success(e.awaitTermination(timeout, unit))
+            ()
+          }
+        catch {
           case ex if NonFatal(ex) =>
             p.failure(ex); ()
         }
@@ -78,10 +80,9 @@ abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporte
 }
 
 object ExecutorScheduler {
-  /** Builder for an [[ExecutorScheduler]], converting a
-    * Java `ScheduledExecutorService`.
+  /** Builder for an [[ExecutorScheduler]], converting a Java `ExecutorService`.
     *
-    * @param service is the Java `ScheduledExecutorService` that will take
+    * @param service is the Java `ExecutorService` that will take
     *        care of scheduling and execution of all runnables.
     * @param reporter is the [[UncaughtExceptionReporter]] that logs uncaught exceptions.
     * @param executionModel is the preferred
@@ -91,22 +92,58 @@ object ExecutorScheduler {
     *        provided `ExecutorService` implements, see the documentation
     *        for [[monix.execution.Scheduler.features Scheduler.features]]
     */
+  @deprecated("Use ExecutorScheduler.fromExecutorService", "3.4.2-avs.6")
   def apply(
     service: ExecutorService,
     reporter: UncaughtExceptionReporter,
     executionModel: ExecModel,
-    features: Features): ExecutorScheduler = {
-
-    // Implementations will inherit BatchingScheduler, so this is guaranteed
-    val ft = features + Scheduler.BATCHING
+    features: Features,
+  ): ExecutorScheduler =
     service match {
-      case ref: ScheduledExecutorService =>
-        new FromScheduledExecutor(ref, reporter, executionModel, ft)
-      case _ =>
-        val s = Defaults.scheduledExecutor
-        new FromSimpleExecutor(s, service, reporter, executionModel, ft)
+      case ref: AdaptedScheduledThreadPoolExecutor => scheduledThreadPool(ref, executionModel, features)
+      case _ => fromExecutorService(service, reporter, executionModel, features)
     }
-  }
+
+  /** Builder for an [[ExecutorScheduler]], converting a Java `ExecutorService`.
+   *
+   * @param service is the Java `ExecutorService` that will take
+   *        care of scheduling and execution of all runnables.
+   * @param reporter is the [[UncaughtExceptionReporter]] that logs uncaught exceptions.
+   * @param executionModel is the preferred
+   *        [[monix.execution.ExecutionModel ExecutionModel]], a guideline
+   *        for run-loops and producers of data.
+   * @param features is the set of [[Features]] that the
+   *        provided `ExecutorService` implements, see the documentation
+   *        for [[monix.execution.Scheduler.features Scheduler.features]]
+   */
+  def fromExecutorService(
+    service: ExecutorService,
+    reporter: UncaughtExceptionReporter,
+    executionModel: ExecModel,
+    features: Features,
+  ): ExecutorScheduler =
+    new FromSimpleExecutor(
+      scheduler = Defaults.scheduledExecutor,
+      executor = service,
+      reporter = reporter,
+      executionModel = executionModel,
+      features = withBatching(features)
+    )
+
+  private[schedulers] def scheduledThreadPool(
+    service: AdaptedScheduledThreadPoolExecutor,
+    executionModel: ExecModel,
+    features: Features,
+  ): ExecutorScheduler =
+    new FromAdaptedThreadPoolExecutor(
+      executor = service,
+      executionModel = executionModel,
+      features = withBatching(features)
+    )
+
+  private def withBatching(features: Features): Features =
+    // Implementations will inherit BatchingScheduler, so this is guaranteed
+    features + Scheduler.BATCHING
 
   /**
     * DEPRECATED — provided for binary backwards compatibility.
@@ -117,9 +154,10 @@ object ExecutorScheduler {
   def apply(
     service: ExecutorService,
     reporter: UncaughtExceptionReporter,
-    executionModel: ExecModel): ExecutorScheduler = {
+    executionModel: ExecModel
+  ): ExecutorScheduler = {
     // $COVERAGE-OFF$
-    apply(service, reporter, executionModel, Features.empty)
+    fromExecutorService(service, reporter, executionModel, Features.empty)
     // $COVERAGE-ON$
   }
 
@@ -131,7 +169,8 @@ object ExecutorScheduler {
     parallelism: Int,
     daemonic: Boolean,
     reporter: UncaughtExceptionReporter,
-    executionModel: ExecModel): ExecutorScheduler = {
+    executionModel: ExecModel,
+  ): ExecutorScheduler = {
 
     val handler = reporter.asJava
     val pool = new AdaptedForkJoinPool(
@@ -142,7 +181,7 @@ object ExecutorScheduler {
       asyncMode = true
     )
 
-    apply(pool, reporter, executionModel, Features.empty)
+    fromExecutorService(pool, reporter, executionModel, Features.empty)
   }
 
   /** Creates an [[ExecutorScheduler]] backed by a `ForkJoinPool`
@@ -154,7 +193,8 @@ object ExecutorScheduler {
     maxThreads: Int,
     daemonic: Boolean,
     reporter: UncaughtExceptionReporter,
-    executionModel: ExecModel): ExecutorScheduler = {
+    executionModel: ExecModel,
+  ): ExecutorScheduler = {
 
     val exceptionHandler = reporter.asJava
     val pool = new AdaptedForkJoinPool(
@@ -165,7 +205,7 @@ object ExecutorScheduler {
       asyncMode = true
     )
 
-    apply(pool, reporter, executionModel, Features.empty)
+    fromExecutorService(pool, reporter, executionModel, Features.empty)
   }
 
   /** Converts a Java `ExecutorService`.
@@ -178,17 +218,18 @@ object ExecutorScheduler {
   private final class FromSimpleExecutor(
     scheduler: ScheduledExecutorService,
     executor: ExecutorService,
-    r: UncaughtExceptionReporter,
+    reporter: UncaughtExceptionReporter,
     override val executionModel: ExecModel,
-    override val features: Features)
-    extends ExecutorScheduler(executor, r) {
+    override val features: Features
+  ) extends ExecutorScheduler(executor, reporter) {
 
     @deprecated("Provided for backwards compatibility", "3.0.0")
     def this(
       scheduler: ScheduledExecutorService,
       executor: ExecutorService,
       r: UncaughtExceptionReporter,
-      executionModel: ExecModel) = {
+      executionModel: ExecModel,
+    ) = {
       // $COVERAGE-OFF$
       this(scheduler, executor, r, executionModel, Features.empty)
       // $COVERAGE-ON$
@@ -198,53 +239,47 @@ object ExecutorScheduler {
       ScheduledExecutors.scheduleOnce(this, scheduler)(initialDelay, unit, r)
 
     override def withExecutionModel(em: ExecModel): SchedulerService =
-      new FromSimpleExecutor(scheduler, executor, r, em, features)
+      new FromSimpleExecutor(scheduler, executor, reporter, em, features)
 
     override def withUncaughtExceptionReporter(r: UncaughtExceptionReporter): SchedulerService =
       new FromSimpleExecutor(scheduler, executor, r, executionModel, features)
   }
 
-  /** Converts a Java `ScheduledExecutorService`. */
-  private final class FromScheduledExecutor(
-    s: ScheduledExecutorService,
-    r: UncaughtExceptionReporter,
+  /** Implementation of ExecutorScheduler backed by Java `ScheduledExecutorService`. Assumes error reporting is done by
+   * the underlying `ScheduledExecutorService`.
+   *
+   * Currently intended for use only with AdaptedThreadPoolExecutor.
+   */
+  private final class FromAdaptedThreadPoolExecutor(
+    executor: AdaptedScheduledThreadPoolExecutor,
     override val executionModel: ExecModel,
-    override val features: Features)
-    extends ExecutorScheduler(s, r) {
-
-    @deprecated("Provided for backwards compatibility", "3.0.0")
-    def this(scheduler: ScheduledExecutorService, r: UncaughtExceptionReporter, executionModel: ExecModel) = {
-      // $COVERAGE-OFF$
-      this(scheduler, r, executionModel, Features.empty)
-      // $COVERAGE-ON$
-    }
-
-    override def executor: ScheduledExecutorService = s
+    override val features: Features
+  ) extends ExecutorScheduler(executor, null) {
 
     def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
       if (initialDelay <= 0) {
         execute(r)
         Cancelable.empty
       } else {
-        val task = s.schedule(r, initialDelay, unit)
+        val task = executor.schedule(r, initialDelay, unit)
         Cancelable(() => { task.cancel(true); () })
       }
     }
 
     override def scheduleWithFixedDelay(initialDelay: Long, delay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-      val task = s.scheduleWithFixedDelay(r, initialDelay, delay, unit)
+      val task = executor.scheduleWithFixedDelay(r, initialDelay, delay, unit)
       Cancelable(() => { task.cancel(false); () })
     }
 
     override def scheduleAtFixedRate(initialDelay: Long, period: Long, unit: TimeUnit, r: Runnable): Cancelable = {
-      val task = s.scheduleAtFixedRate(r, initialDelay, period, unit)
+      val task = executor.scheduleAtFixedRate(r, initialDelay, period, unit)
       Cancelable(() => { task.cancel(false); () })
     }
 
     override def withExecutionModel(em: ExecModel): SchedulerService =
-      new FromScheduledExecutor(s, r, em, features)
+      new FromAdaptedThreadPoolExecutor(executor, em, features)
 
     override def withUncaughtExceptionReporter(r: UncaughtExceptionReporter): SchedulerService =
-      new FromScheduledExecutor(s, r, executionModel, features)
+      new FromAdaptedThreadPoolExecutor(executor.withUncaughtExceptionReporter(r), executionModel, features)
   }
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -36,7 +36,11 @@ import scala.util.control.NonFatal
 abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporter, additionalFeatures: Features)
   extends SchedulerService with ReferenceScheduler with BatchingScheduler {
 
-  override final val features: Features = additionalFeatures + Scheduler.BATCHING
+  private val allFeatures: Features = additionalFeatures + Scheduler.BATCHING
+
+  // for backwards compatibility
+  def this(e: ExecutorService, r: UncaughtExceptionReporter) =
+    this(e, r, Features.empty)
 
   /** Returns the underlying `ExecutorService` reference. */
   def executor: ExecutorService = e
@@ -79,6 +83,8 @@ abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporte
     throw new NotImplementedError("ExecutorService.withUncaughtExceptionReporter")
     // $COVERAGE-ON$
   }
+
+  override def features: Features = allFeatures
 }
 
 object ExecutorScheduler {

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/ExecutorScheduler.scala
@@ -33,8 +33,10 @@ import scala.util.control.NonFatal
   * [[monix.execution.schedulers.SchedulerService SchedulerService]]
   * out of a Java `ExecutorService`.
   */
-abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporter)
+abstract class ExecutorScheduler(e: ExecutorService, r: UncaughtExceptionReporter, additionalFeatures: Features)
   extends SchedulerService with ReferenceScheduler with BatchingScheduler {
+
+  override final val features: Features = additionalFeatures + Scheduler.BATCHING
 
   /** Returns the underlying `ExecutorService` reference. */
   def executor: ExecutorService = e
@@ -127,7 +129,7 @@ object ExecutorScheduler {
       executor = service,
       reporter = reporter,
       executionModel = executionModel,
-      features = withBatching(features)
+      additionalFeatures = features,
     )
 
   private[schedulers] def scheduledThreadPool(
@@ -138,12 +140,8 @@ object ExecutorScheduler {
     new FromAdaptedThreadPoolExecutor(
       executor = service,
       executionModel = executionModel,
-      features = withBatching(features)
+      additionalFeatures = features,
     )
-
-  private def withBatching(features: Features): Features =
-    // Implementations will inherit BatchingScheduler, so this is guaranteed
-    features + Scheduler.BATCHING
 
   /**
     * DEPRECATED — provided for binary backwards compatibility.
@@ -220,8 +218,8 @@ object ExecutorScheduler {
     executor: ExecutorService,
     reporter: UncaughtExceptionReporter,
     override val executionModel: ExecModel,
-    override val features: Features
-  ) extends ExecutorScheduler(executor, reporter) {
+    additionalFeatures: Features,
+  ) extends ExecutorScheduler(executor, reporter, additionalFeatures) {
 
     @deprecated("Provided for backwards compatibility", "3.0.0")
     def this(
@@ -239,10 +237,10 @@ object ExecutorScheduler {
       ScheduledExecutors.scheduleOnce(this, scheduler)(initialDelay, unit, r)
 
     override def withExecutionModel(em: ExecModel): SchedulerService =
-      new FromSimpleExecutor(scheduler, executor, reporter, em, features)
+      new FromSimpleExecutor(scheduler, executor, reporter, em, additionalFeatures)
 
     override def withUncaughtExceptionReporter(r: UncaughtExceptionReporter): SchedulerService =
-      new FromSimpleExecutor(scheduler, executor, r, executionModel, features)
+      new FromSimpleExecutor(scheduler, executor, r, executionModel, additionalFeatures)
   }
 
   /** Implementation of ExecutorScheduler backed by Java `ScheduledExecutorService`. Assumes error reporting is done by
@@ -253,8 +251,8 @@ object ExecutorScheduler {
   private final class FromAdaptedThreadPoolExecutor(
     executor: AdaptedScheduledThreadPoolExecutor,
     override val executionModel: ExecModel,
-    override val features: Features
-  ) extends ExecutorScheduler(executor, null) {
+    additionalFeatures: Features,
+  ) extends ExecutorScheduler(executor, null, additionalFeatures) {
 
     def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable = {
       if (initialDelay <= 0) {
@@ -277,9 +275,9 @@ object ExecutorScheduler {
     }
 
     override def withExecutionModel(em: ExecModel): SchedulerService =
-      new FromAdaptedThreadPoolExecutor(executor, em, features)
+      new FromAdaptedThreadPoolExecutor(executor, em, additionalFeatures)
 
     override def withUncaughtExceptionReporter(r: UncaughtExceptionReporter): SchedulerService =
-      new FromAdaptedThreadPoolExecutor(executor.withUncaughtExceptionReporter(r), executionModel, features)
+      new FromAdaptedThreadPoolExecutor(executor.withUncaughtExceptionReporter(r), executionModel, additionalFeatures)
   }
 }

--- a/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
+++ b/monix-execution/jvm/src/main/scala/monix/execution/schedulers/SchedulerCompanionImpl.scala
@@ -112,7 +112,7 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
     * @param reporter $reporter
     */
   def apply(executor: ExecutorService, reporter: UncaughtExceptionReporter): SchedulerService =
-    ExecutorScheduler(executor, reporter, ExecModel.Default, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, reporter, ExecModel.Default, Features.empty)
 
   /** [[monix.execution.Scheduler Scheduler]] builder that converts a
     * Java `ExecutorService` into a scheduler.
@@ -124,10 +124,8 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
   def apply(
     executor: ExecutorService,
     reporter: UncaughtExceptionReporter,
-    executionModel: ExecModel): SchedulerService = {
-
-    ExecutorScheduler(executor, reporter, executionModel, Features.empty)
-  }
+    executionModel: ExecModel): SchedulerService =
+    ExecutorScheduler.fromExecutorService(executor, reporter, executionModel, Features.empty)
 
   /** [[monix.execution.Scheduler Scheduler]] builder that converts a
     * Java `ExecutorService` into a scheduler.
@@ -135,7 +133,7 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
     * @param executor $executorService
     */
   def apply(executor: ExecutorService): SchedulerService =
-    ExecutorScheduler(executor, UncaughtExceptionReporter.default, ExecModel.Default, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, UncaughtExceptionReporter.default, ExecModel.Default, Features.empty)
 
   /** [[monix.execution.Scheduler Scheduler]] builder that converts a
     * Java `ExecutorService` into a scheduler.
@@ -144,7 +142,7 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
     * @param executionModel $executionModel
     */
   def apply(executor: ExecutorService, executionModel: ExecModel): SchedulerService =
-    ExecutorScheduler(executor, UncaughtExceptionReporter.default, executionModel, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, UncaughtExceptionReporter.default, executionModel, Features.empty)
 
   /** [[monix.execution.Scheduler Scheduler]] builder - uses monix's
     * default `ScheduledExecutorService` for handling the scheduling of tasks.
@@ -298,7 +296,7 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
       new SynchronousQueue[Runnable](false),
       threadFactory)
 
-    ExecutorScheduler(executor, reporter, executionModel, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, reporter, executionModel, Features.empty)
   }
 
   /** Builds a [[Scheduler]] backed by an internal
@@ -340,7 +338,7 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
       new SynchronousQueue[Runnable](false),
       threadFactory)
 
-    ExecutorScheduler(executor, reporter, executionModel, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, reporter, executionModel, Features.empty)
   }
 
   /** Builds a [[monix.execution.Scheduler Scheduler]] that schedules and executes tasks on its own thread.
@@ -365,12 +363,9 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
     executionModel: ExecModel = ExecModel.Default): SchedulerService = {
 
     val factory = ThreadFactoryBuilder(name, reporter, daemonic)
-    val executor = new AdaptedThreadPoolExecutor(1, factory) {
-      override def reportFailure(t: Throwable): Unit =
-        reporter.reportFailure(t)
-    }
+    val executor = new AdaptedScheduledThreadPoolExecutor(1, factory, reporter)
 
-    ExecutorScheduler(executor, null, executionModel, Features.empty)
+    ExecutorScheduler.scheduledThreadPool(executor, executionModel, Features.empty)
   }
 
   /** Builds a [[monix.execution.Scheduler Scheduler]] with a fixed thread-pool.
@@ -394,12 +389,9 @@ private[execution] class SchedulerCompanionImpl extends SchedulerCompanion {
     executionModel: ExecModel = ExecModel.Default): SchedulerService = {
 
     val factory = ThreadFactoryBuilder(name, reporter, daemonic)
-    val executor = new AdaptedThreadPoolExecutor(poolSize, factory) {
-      override def reportFailure(t: Throwable): Unit =
-        reporter.reportFailure(t)
-    }
+    val executor = new AdaptedScheduledThreadPoolExecutor(poolSize, factory, reporter)
 
-    ExecutorScheduler(executor, null, executionModel, Features.empty)
+    ExecutorScheduler.scheduledThreadPool(executor, executionModel, Features.empty)
   }
 
   /** The explicit global `Scheduler`. Invoke `global` when you want

--- a/monix-execution/jvm/src/test/scala/monix/execution/FeaturesJVMSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/FeaturesJVMSuite.scala
@@ -70,7 +70,12 @@ object FeaturesJVMSuite extends SimpleTestSuite with Checkers {
   test("ExecutorScheduler(Executor") {
     val ref = {
       val ec = Executors.newSingleThreadExecutor()
-      ExecutorScheduler(ec, UncaughtExceptionReporter.default, ExecutionModel.Default, Features.empty)
+      ExecutorScheduler.fromExecutorService(
+        ec,
+        UncaughtExceptionReporter.default,
+        ExecutionModel.Default,
+        Features.empty
+      )
     }
     try {
       assert(ref.features.contains(Scheduler.BATCHING))
@@ -83,7 +88,12 @@ object FeaturesJVMSuite extends SimpleTestSuite with Checkers {
   test("ExecutorScheduler(ScheduledExecutor") {
     val ref = {
       val ec = Executors.newSingleThreadScheduledExecutor()
-      ExecutorScheduler(ec, UncaughtExceptionReporter.default, ExecutionModel.Default, Features.empty)
+      ExecutorScheduler.fromExecutorService(
+        ec,
+        UncaughtExceptionReporter.default,
+        ExecutionModel.Default,
+        Features.empty
+      )
     }
     try {
       assert(ref.features.contains(Scheduler.BATCHING))
@@ -96,7 +106,12 @@ object FeaturesJVMSuite extends SimpleTestSuite with Checkers {
   test("ExecutorScheduler(ScheduledExecutor)") {
     val ref = {
       val ec = Executors.newSingleThreadScheduledExecutor()
-      ExecutorScheduler(ec, UncaughtExceptionReporter.default, ExecutionModel.Default, Features.empty)
+      ExecutorScheduler.fromExecutorService(
+        ec,
+        UncaughtExceptionReporter.default,
+        ExecutionModel.Default,
+        Features.empty
+      )
     }
     try {
       assert(ref.features.contains(Scheduler.BATCHING))

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -17,16 +17,15 @@
 
 package monix.execution.schedulers
 
-import java.util.concurrent.{CountDownLatch, TimeUnit, TimeoutException}
-
 import minitest.TestSuite
 import monix.execution.ExecutionModel.{AlwaysAsyncExecution, Default => DefaultExecutionModel}
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.DummyException
 import monix.execution.{Cancelable, Scheduler, UncaughtExceptionReporter}
 
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit, TimeoutException}
 import scala.concurrent.duration._
-import scala.concurrent.{blocking, Await, Promise}
+import scala.concurrent.{Await, Promise, blocking}
 
 abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self =>
   var lastReportedFailure = null: Throwable
@@ -101,7 +100,8 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
         } else if (value < 4) {
           value += 1
         }
-      })
+      }
+    )
 
     assert(Await.result(p.future, 5.second) == 4)
   }
@@ -124,7 +124,8 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
         } else if (value < 4) {
           value += 1
         }
-      })
+      }
+    )
 
     assert(Await.result(p.future, 5.second) == 4)
   }
@@ -188,14 +189,60 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
       scheduler.scheduleOnce(
         1,
         TimeUnit.MILLISECONDS,
-        new Runnable {
-          override def run() =
-            throw ex
-        })
+        () => throw ex,
+      )
 
       assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
       self.synchronized(assertEquals(lastReportedFailure, ex))
     } finally {
+      self.synchronized {
+        lastReportedFailure = null
+        lastReportedFailureLatch = null
+      }
+    }
+  }
+
+  test("reports errors on scheduleAtFixedRate") { scheduler =>
+    val latch = new CountDownLatch(1)
+    self.synchronized {
+      lastReportedFailure = null
+      lastReportedFailureLatch = latch
+    }
+
+    val ex = DummyException("dummy")
+    val schedule = scheduler.scheduleAtFixedRate(0.seconds, 1.second) {
+      throw ex
+    }
+
+    try {
+      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
+      self.synchronized(assertEquals(lastReportedFailure, ex))
+    } finally {
+      schedule.cancel()
+      self.synchronized {
+        lastReportedFailure = null
+        lastReportedFailureLatch = null
+      }
+    }
+  }
+
+  test("reports errors on scheduleWithFixedDelay") { scheduler =>
+    val latch = new CountDownLatch(1)
+    self.synchronized {
+      lastReportedFailure = null
+      lastReportedFailureLatch = latch
+    }
+
+    val ex = DummyException("dummy")
+    val schedule = scheduler.scheduleWithFixedDelay(0.seconds, 1.second) {
+      throw ex
+    }
+
+    try {
+      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
+      self.synchronized(assertEquals(lastReportedFailure, ex))
+    } finally {
+      schedule.cancel()
       self.synchronized {
         lastReportedFailure = null
         lastReportedFailureLatch = null
@@ -255,4 +302,9 @@ object CachedSchedulerSuite extends ExecutorSchedulerSuite {
 object IOSchedulerSuite extends ExecutorSchedulerSuite {
   def setup(): SchedulerService =
     monix.execution.Scheduler.io("monix-tests-io", reporter = testsReporter)
+}
+
+object ScheduledExecutorSuite extends ExecutorSchedulerSuite {
+  def setup(): SchedulerService =
+    monix.execution.Scheduler(Executors.newSingleThreadScheduledExecutor(), reporter = testsReporter)
 }

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ExecutorSchedulerSuite.scala
@@ -21,6 +21,7 @@ import minitest.TestSuite
 import monix.execution.ExecutionModel.{AlwaysAsyncExecution, Default => DefaultExecutionModel}
 import monix.execution.cancelables.SingleAssignCancelable
 import monix.execution.exceptions.DummyException
+import monix.execution.schedulers.ExecutorSchedulerSuite.TestException
 import monix.execution.{Cancelable, Scheduler, UncaughtExceptionReporter}
 
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit, TimeoutException}
@@ -152,106 +153,75 @@ abstract class ExecutorSchedulerSuite extends TestSuite[SchedulerService] { self
   }
 
   test("reports errors on execute") { scheduler =>
-    val latch = new CountDownLatch(1)
-    self.synchronized {
-      lastReportedFailure = null
-      lastReportedFailureLatch = latch
-    }
+    val latch = setupReporterLatch()
 
     try {
-      val ex = DummyException("dummy")
+      scheduler.execute(() => throw TestException)
 
-      scheduler.execute(new Runnable {
-        override def run() =
-          throw ex
-      })
-
-      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
-      self.synchronized(assertEquals(lastReportedFailure, ex))
+      assertTestExceptionCaught(latch)
     } finally {
-      self.synchronized {
-        lastReportedFailure = null
-        lastReportedFailureLatch = null
-      }
+      clearReporterLatch()
     }
   }
 
   test("reports errors on scheduleOnce") { scheduler =>
-    val latch = new CountDownLatch(1)
-    self.synchronized {
-      lastReportedFailure = null
-      lastReportedFailureLatch = latch
-    }
-
-    try {
-      val ex = DummyException("dummy")
-
-      scheduler.scheduleOnce(
-        1,
-        TimeUnit.MILLISECONDS,
-        () => throw ex,
-      )
-
-      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
-      self.synchronized(assertEquals(lastReportedFailure, ex))
-    } finally {
-      self.synchronized {
-        lastReportedFailure = null
-        lastReportedFailureLatch = null
-      }
-    }
+    testScheduledErrorReporting(
+      scheduleFailure = () => scheduler.scheduleOnce(1.milli)(throw TestException)
+    )
   }
 
   test("reports errors on scheduleAtFixedRate") { scheduler =>
-    val latch = new CountDownLatch(1)
-    self.synchronized {
-      lastReportedFailure = null
-      lastReportedFailureLatch = latch
-    }
-
-    val ex = DummyException("dummy")
-    val schedule = scheduler.scheduleAtFixedRate(0.seconds, 1.second) {
-      throw ex
-    }
-
-    try {
-      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
-      self.synchronized(assertEquals(lastReportedFailure, ex))
-    } finally {
-      schedule.cancel()
-      self.synchronized {
-        lastReportedFailure = null
-        lastReportedFailureLatch = null
-      }
-    }
+    testScheduledErrorReporting(
+      scheduleFailure = () => scheduler.scheduleAtFixedRate(0.seconds, 1.second)(throw TestException)
+    )
   }
 
   test("reports errors on scheduleWithFixedDelay") { scheduler =>
+    testScheduledErrorReporting(
+      scheduleFailure = () => scheduler.scheduleWithFixedDelay(0.seconds, 1.second)(throw TestException),
+    )
+  }
+
+  private def testScheduledErrorReporting(scheduleFailure: () => Cancelable): Unit = {
+    val latch = setupReporterLatch()
+
+    val schedule = scheduleFailure()
+
+    try {
+      assertTestExceptionCaught(latch)
+    } finally {
+      schedule.cancel()
+      clearReporterLatch()
+    }
+  }
+
+  private def setupReporterLatch() = {
     val latch = new CountDownLatch(1)
     self.synchronized {
       lastReportedFailure = null
       lastReportedFailureLatch = latch
     }
+    latch
+  }
 
-    val ex = DummyException("dummy")
-    val schedule = scheduler.scheduleWithFixedDelay(0.seconds, 1.second) {
-      throw ex
-    }
+  private def assertTestExceptionCaught(latch: CountDownLatch): Unit = {
+    assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
+    self.synchronized(assertEquals(lastReportedFailure, TestException))
+  }
 
-    try {
-      assert(latch.await(15, TimeUnit.MINUTES), "lastReportedFailureLatch.await")
-      self.synchronized(assertEquals(lastReportedFailure, ex))
-    } finally {
-      schedule.cancel()
-      self.synchronized {
-        lastReportedFailure = null
-        lastReportedFailureLatch = null
-      }
+  private def clearReporterLatch(): Unit = {
+    self.synchronized {
+      lastReportedFailure = null
+      lastReportedFailureLatch = null
     }
   }
 
   def runnableAction(f: => Unit): Runnable =
     new Runnable { def run() = f }
+}
+
+object ExecutorSchedulerSuite {
+  private val TestException = DummyException("dummy")
 }
 
 object ComputationSchedulerSuite extends ExecutorSchedulerSuite {

--- a/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
+++ b/monix-execution/jvm/src/test/scala/monix/execution/schedulers/ScheduledExecutorToSchedulerSuite.scala
@@ -41,7 +41,7 @@ object ScheduledExecutorToSchedulerSuite extends TestSuite[ExecutorScheduler] {
         daemonic = true
       ))
 
-    ExecutorScheduler(executor, reporter, ExecModel.Default, Features.empty)
+    ExecutorScheduler.fromExecutorService(executor, reporter, ExecModel.Default, Features.empty)
   }
 
   override def tearDown(scheduler: ExecutorScheduler): Unit = {

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -115,15 +115,15 @@ object ReferenceScheduler {
     private[this] val reporterRef = if (reporter eq null) s else reporter
 
     override def execute(runnable: Runnable): Unit =
-      s.execute(InterceptRunnable(runnable, reporterRef))
+      s.execute(InterceptRunnable(runnable, reporter))
     override def reportFailure(t: Throwable): Unit =
       reporterRef.reportFailure(t)
     override def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleOnce(initialDelay, unit, InterceptRunnable(r, reporterRef))
+      s.scheduleOnce(initialDelay, unit, InterceptRunnable(r, reporter))
     override def scheduleWithFixedDelay(initialDelay: Long, delay: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleWithFixedDelay(initialDelay, delay, unit, InterceptRunnable(r, reporterRef))
+      s.scheduleWithFixedDelay(initialDelay, delay, unit, InterceptRunnable(r, reporter))
     override def scheduleAtFixedRate(initialDelay: Long, period: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleAtFixedRate(initialDelay, period, unit, InterceptRunnable(r, reporterRef))
+      s.scheduleAtFixedRate(initialDelay, period, unit, InterceptRunnable(r, reporter))
     override def clockRealTime(unit: TimeUnit): Long =
       s.clockRealTime(unit)
     override def clockMonotonic(unit: TimeUnit): Long =

--- a/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
+++ b/monix-execution/shared/src/main/scala/monix/execution/schedulers/ReferenceScheduler.scala
@@ -115,15 +115,15 @@ object ReferenceScheduler {
     private[this] val reporterRef = if (reporter eq null) s else reporter
 
     override def execute(runnable: Runnable): Unit =
-      s.execute(InterceptRunnable(runnable, reporter))
+      s.execute(InterceptRunnable(runnable, reporterRef))
     override def reportFailure(t: Throwable): Unit =
       reporterRef.reportFailure(t)
     override def scheduleOnce(initialDelay: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleOnce(initialDelay, unit, r)
+      s.scheduleOnce(initialDelay, unit, InterceptRunnable(r, reporterRef))
     override def scheduleWithFixedDelay(initialDelay: Long, delay: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleWithFixedDelay(initialDelay, delay, unit, r)
+      s.scheduleWithFixedDelay(initialDelay, delay, unit, InterceptRunnable(r, reporterRef))
     override def scheduleAtFixedRate(initialDelay: Long, period: Long, unit: TimeUnit, r: Runnable): Cancelable =
-      s.scheduleAtFixedRate(initialDelay, period, unit, r)
+      s.scheduleAtFixedRate(initialDelay, period, unit, InterceptRunnable(r, reporterRef))
     override def clockRealTime(unit: TimeUnit): Long =
       s.clockRealTime(unit)
     override def clockMonotonic(unit: TimeUnit): Long =

--- a/monix-execution/shared/src/test/scala/monix/execution/schedulers/UncaughtExceptionReporterSuite.scala
+++ b/monix-execution/shared/src/test/scala/monix/execution/schedulers/UncaughtExceptionReporterSuite.scala
@@ -17,10 +17,11 @@
 
 package monix.execution.schedulers
 
-import scala.concurrent.{ExecutionContext, Promise}
-import scala.concurrent.duration._
 import minitest.TestSuite
 import monix.execution.{ExecutionModel, FutureUtils, Scheduler, UncaughtExceptionReporter}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Promise}
 
 class UncaughtExceptionReporterBaseSuite extends TestSuite[Promise[Throwable]] {
   protected val immediateEC = TrampolineExecutionContext.immediate
@@ -41,13 +42,42 @@ class UncaughtExceptionReporterBaseSuite extends TestSuite[Promise[Throwable]] {
   def testReports(name: String)(f: UncaughtExceptionReporter => Scheduler) = {
     testAsync(name) { p =>
       f(reporter(p)).execute(throwRunnable)
-      FutureUtils.timeout(p.future.collect { case Dummy => }(immediateEC), 500.millis)(Scheduler.global)
+      assertExceptionCaught(p)
     }
 
     testAsync(name + ".withUncaughtExceptionReporter") { p =>
       f(UncaughtExceptionReporter.default).withUncaughtExceptionReporter(reporter(p)).execute(throwRunnable)
-      FutureUtils.timeout(p.future.collect { case Dummy => }(immediateEC), 500.millis)(Scheduler.global)
+      assertExceptionCaught(p)
     }
+
+    testAsync(name + ".withUncaughtExceptionReporter + scheduleOnce") { p =>
+      f(UncaughtExceptionReporter.default)
+        .withUncaughtExceptionReporter(reporter(p))
+        .scheduleOnce(1.milli)(throwRunnable.run())
+      assertExceptionCaught(p)
+    }
+
+    testAsync(name + ".withUncaughtExceptionReporter + scheduleAtFixedRate") { p =>
+      val schedule = f(UncaughtExceptionReporter.default)
+        .withUncaughtExceptionReporter(reporter(p))
+        .scheduleAtFixedRate(0.millis, 1.second)(throwRunnable.run())
+      val result = assertExceptionCaught(p)
+      result.onComplete(_ => schedule.cancel())(immediateEC)
+      result
+    }
+
+    testAsync(name + ".withUncaughtExceptionReporter + scheduleWithFixedDelay") { p =>
+      val schedule = f(UncaughtExceptionReporter.default)
+        .withUncaughtExceptionReporter(reporter(p))
+        .scheduleWithFixedDelay(0.millis, 1.second)(throwRunnable.run())
+      val result = assertExceptionCaught(p)
+      result.onComplete(_ => schedule.cancel())(immediateEC)
+      result
+    }
+  }
+
+  private def assertExceptionCaught(p: Promise[Throwable]) = {
+    FutureUtils.timeout(p.future.collect { case Dummy => }(immediateEC), 500.millis)(Scheduler.global)
   }
 }
 

--- a/project/MimaFilters.scala
+++ b/project/MimaFilters.scala
@@ -105,6 +105,8 @@ object MimaFilters {
     // TrampolineExecutionContext signature tweaks (internal API)
     exclude[IncompatibleMethTypeProblem]("monix.execution.schedulers.TrampolineExecutionContext#JVMNormalTrampoline.startLoop"),
     exclude[IncompatibleMethTypeProblem]("monix.execution.schedulers.TrampolineExecutionContext#JVMOptimalTrampoline.startLoop"),
-    exclude[IncompatibleMethTypeProblem]("monix.execution.schedulers.TrampolineExecutionContext.this")
+    exclude[IncompatibleMethTypeProblem]("monix.execution.schedulers.TrampolineExecutionContext.this"),
+    exclude[MissingClassProblem]("monix.execution.schedulers.AdaptedThreadPoolExecutor"),
+    exclude[MissingClassProblem]("monix.execution.schedulers.ExecutorScheduler$FromScheduledExecutor"),
   )
 }


### PR DESCRIPTION
## Summary
In JDK 25 `ForkJoinPool` implements `ScheduledExecutorService`. This change resulted in incorrect error reporting and failing tests in #6.

## Problem

Monix has two internal implementations of `ExecutorScheduler`:
- `FromSimpleExecutor` - for regular `ExecutorService`
- `FromScheduledExecutor` - for `ScheduledExecutorService`

The `FromScheduledExecutor` implementation relies on error reporting being done by the underlying executor itself (via `afterExecute` hook), but this only works correctly with `AdaptedThreadPoolExecutor` (Monix's custom implementation). For other `ScheduledExecutorService` implementations, error reporting did not work properly.

Before JDK 25 this problem wasn't visible, because almost all `Scheduler` factory methods use `AsyncScheduler`, `FromSimpleExecutor`  or `FromScheduledExecutor` together with `AdaptedThreadPoolExecutor`.

Additionally, `withUncaughtExceptionReporter` didn't work correctly for all scheduler methods in wrapped schedulers (`AsyncScheduler`, etc.) - the updated reporter wasn't being used for `scheduleOnce`, `scheduleAtFixedRate`, and `scheduleWithFixedDelay`.

## Changes

1. **Restricted `FromScheduledExecutor` (now `FromAdaptedThreadPoolExecutor`) usage** - This implementation is now only used for schedulers backed by `AdaptedScheduledThreadPoolExecutor`. All other `ExecutorService` implementations (including `ScheduledExecutorService` and `ForkJoinPool`) use `FromSimpleExecutor`.

2. **Fixed error reporting in wrapped schedulers (`ReferenceScheduler`)** - The `scheduleOnce`, `scheduleAtFixedRate`, and `scheduleWithFixedDelay` methods now wrap runnables with `InterceptRunnable` to pass exceptions to correct reporters.
